### PR TITLE
Update npm testing commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,8 @@
   "scripts": {
     "start": "node scripts/start.js",
     "build": "node scripts/build.js",
-    "test": "jest --watch --env=jsdom",
+    "test": "jest --env=jsdom",
+    "test:watch": "jest --watch --env=jsdom",
     "storybook": "start-storybook -p 9009",
     "build-storybook": "build-storybook"
   },


### PR DESCRIPTION
- `npm test` no longer watches by default
- Additional `npm run test:watch` command for running tests
  with watching
