### PR TITLE
Add Jest environment to eslint configuration

### DIFF
--- a/config/eslint.js
+++ b/config/eslint.js
@@ -5,6 +5,9 @@ module.exports = {
     classes: true,
     jsx: true,
   },
+  env: {
+    jest: true,
+  },
   plugins: [
     'flowtype',
     'jsx-a11y',


### PR DESCRIPTION
Stops Jest global variables from causing lint issues in our tests
