### PR TITLE
Add caption support to `<Hero />` component

### DIFF
--- a/components/Hero/Hero.css
+++ b/components/Hero/Hero.css
@@ -20,9 +20,21 @@
   background-color: var(--overlay-default);
 }
 
+.caption {
+  display: none;
+}
+
 /* Media query variable support pls */
 @media(--hero-large) {
   .inner {
     padding: var(--space-200) var(--space-200);
+  }
+
+  .caption {
+    display: block;
+    position: absolute;
+    color: var(--color-greyLight);
+    bottom: var(--size-large);
+    right: var(--size-large);
   }
 }

--- a/components/Hero/Hero.js
+++ b/components/Hero/Hero.js
@@ -1,6 +1,7 @@
 import React, { PropTypes } from 'react';
 import classnames from 'classnames';
 
+import m from '../../globals/modifiers.css';
 import css from './Hero.css';
 
 const Hero = (props) => {
@@ -8,6 +9,7 @@ const Hero = (props) => {
     className,
     backgroundImage,
     children,
+    caption,
     ...rest,
   } = props;
 
@@ -21,6 +23,11 @@ const Hero = (props) => {
     backgroundImage ? css.innerOverlay : null,
   );
 
+  const captionClasses = classnames(
+    css.caption,
+    m.fontBase,
+  )
+
   const styles = { backgroundImage: `url(${backgroundImage})` };
 
   return (
@@ -32,6 +39,11 @@ const Hero = (props) => {
       <div className={ innerClasses }>
         { children }
       </div>
+      { caption && backgroundImage && (
+        <div className={ captionClasses }>
+          { caption }
+        </div>
+      )}
     </div>
   );
 };
@@ -40,6 +52,7 @@ Hero.propTypes = {
   className: PropTypes.string,
   backgroundImage: PropTypes.string,
   children: PropTypes.node.isRequired,
+  caption: PropTypes.node,
 };
 
 export default Hero;

--- a/components/Hero/Hero.story.js
+++ b/components/Hero/Hero.story.js
@@ -23,6 +23,7 @@ storiesOf('Hero', module)
       <Hero
         className={ m.bgBlack }
         backgroundImage="https://unsplash.it/1600/1201"
+        caption="A random image from unsplash"
       >
         <h1 className={ headingClasses }>List a space, host an idea</h1>
         <p className={ paraClasses }>

--- a/globals/colors.css
+++ b/globals/colors.css
@@ -19,6 +19,7 @@
   /* Application colors */
   --color-red: rgb(213, 84, 68);
   --color-green: rgb(72, 213, 108);
+  --color-greyLight: rgb(228, 228, 228);
 
   /* Application tints */
   --color-red--light: rgb(236, 94, 77);


### PR DESCRIPTION
When a background image has been supplied, a caption
can also be supplied. This is useful in instances where
the background image might be depicting a space or brand
which we want to link to the space page or case study
