### PR TITLE
Add simple <Carousel /> component

### DIFF
--- a/components/Carousel/Carousel.css
+++ b/components/Carousel/Carousel.css
@@ -1,0 +1,19 @@
+.root {
+  white-space: nowrap;
+  -webkit-overflow-scrolling: touch;
+  width: 100%;
+}
+
+.root * {
+  box-sizing: border-box;
+}
+
+.animate {
+  transition: transform 500ms;
+}
+
+.slide {
+  display: inline-block;
+  padding-left: 2px;
+  padding-right: 2px;
+}

--- a/components/Carousel/Carousel.js
+++ b/components/Carousel/Carousel.js
@@ -1,0 +1,41 @@
+import React, { PropTypes, Component } from 'react';
+
+import Inner from './CarouselInner';
+import getValidIndex from '../../utils/getValidIndex/getValidIndex';
+
+export default class Carousel extends Component {
+  static propTypes = {
+    lowestVisibleItemIndex: PropTypes.number,
+    items: PropTypes.array.isRequired,
+    itemsPerColumn: PropTypes.number,
+  };
+
+  static defaultProps = {
+    lowestVisibleItemIndex: 0,
+    items: [],
+    itemsPerColumn: 1,
+  };
+
+  render() {
+    const { items, itemsPerColumn, lowestVisibleItemIndex } = this.props;
+
+    const renderPerColumn = itemsPerColumn < items.length ? itemsPerColumn : items.length;
+    const slideWidth = 100 / renderPerColumn;
+
+    const position = lowestVisibleItemIndex * (-1 * slideWidth);
+    const transform = `translate3d(${position}%, 0, 0)`;
+
+    return (
+      <div>
+        <Inner
+          style={ {
+            transform,
+          } }
+          slideWidth={ slideWidth }
+        >
+          { items }
+        </Inner>
+      </div>
+    );
+  }
+}

--- a/components/Carousel/Carousel.story.js
+++ b/components/Carousel/Carousel.story.js
@@ -1,0 +1,73 @@
+import React, { PropTypes, Component } from 'react';
+import { storiesOf } from '@kadira/storybook';
+import Carousel from './Carousel';
+
+import getValidIndex from '../../utils/getValidIndex/getValidIndex';
+
+const Slide = ({ i }) => (
+  <div
+    style={ {
+      width: '100%',
+      height: '300px',
+    } }
+  >
+    <div
+      style={ {
+        width: '100%',
+        height: '300px',
+        backgroundColor: 'red',
+      } }
+    >
+      slide { i }
+    </div>
+  </div>
+);
+
+Slide.propTypes = {
+  i: PropTypes.number,
+};
+
+const slides = [<Slide i={ 0 } />, <Slide i={ 1 } />, <Slide i={ 2 } />, <Slide i={ 3 } />, <Slide i={ 4 } />, <Slide i={ 5 } />, <Slide i={ 6 } />, <Slide i={ 7 } />];
+
+class TestComponent extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      lowestVisibleItemIndex: 0,
+      itemsPerColumn: 1,
+    }
+  }
+
+  goToIndex = (i) => {
+    const { itemsPerColumn } = this.state;
+
+    if (i < 0 || i >= slides.length) return;
+    const lowestVisibleItemIndex = getValidIndex(i, slides.length, itemsPerColumn);
+    this.setState({ lowestVisibleItemIndex });
+  }
+
+  render() {
+    const { lowestVisibleItemIndex, itemsPerColumn } = this.state;
+
+    return (
+      <div style={ { width: '80vW', overflowX: 'visible', margin: '0 auto' } }>
+        <Carousel
+          lowestVisibleItemIndex={ lowestVisibleItemIndex }
+          items={ slides }
+          itemsPerColumn={ itemsPerColumn }
+        />
+        <button onClick={this.goToIndex.bind(this, 0)}>Go to 0</button>
+        <button onClick={this.goToIndex.bind(this, 1)}>Go to 1</button>
+        <button onClick={this.goToIndex.bind(this, 2)}>Go to 2</button>
+        <button onClick={this.goToIndex.bind(this, 3)}>Go to 3</button>
+        <button onClick={this.goToIndex.bind(this, 4)}>Go to 4</button>
+      </div>
+    );
+  }
+}
+
+storiesOf('Carousel', module)
+  .add('Default', () => (
+    <TestComponent />
+  ));

--- a/components/Carousel/Carousel.test.js
+++ b/components/Carousel/Carousel.test.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { createRenderer } from 'react-addons-test-utils';
+
+import Carousel from './Carousel';
+
+it('renders without crashing', () => {
+  const div = document.createElement('div');
+  ReactDOM.render(<Carousel />, div);
+});
+
+it('calculates the width of slides correctly ', () => {
+  const items = [<div key="lmao" />, <div key="lol" />];
+  const shallowRenderer = createRenderer();
+  let result = null;
+
+  shallowRenderer.render(
+    <Carousel
+      items={items}
+      itemsPerColumn={1}
+    />
+  );
+
+  result = shallowRenderer.getRenderOutput();
+  expect(result.props.children.props.slideWidth).toBe(100);
+
+  shallowRenderer.render(
+    <Carousel
+      items={items}
+      itemsPerColumn={2}
+    />
+  );
+
+  result = shallowRenderer.getRenderOutput();
+  expect(result.props.children.props.slideWidth).toBe(50);
+
+  shallowRenderer.render(
+    <Carousel
+      items={items}
+      itemsPerColumn={3}
+    />
+  );
+
+  result = shallowRenderer.getRenderOutput();
+  expect(result.props.children.props.slideWidth).toBe(50);
+});

--- a/components/Carousel/CarouselInner.js
+++ b/components/Carousel/CarouselInner.js
@@ -1,0 +1,37 @@
+import React, { PropTypes } from 'react';
+import cx from 'classnames';
+
+import css from './Carousel.css';
+
+const CarouselInner = ({ children, className, style, slideWidth = 100, ...rest }) => {
+  const classes = cx(css.root, css.animate, className);
+
+  return (
+    <div
+      className={ classes }
+      style={ style }
+      { ...rest }
+    >
+      { children.map((slide, i) => (
+        <div
+          key={ i }
+          className={ css.slide }
+          style={ {
+            width: `${slideWidth}%`,
+          } }
+        >
+          { slide }
+        </div>
+      )) }
+    </div>
+  );
+};
+
+CarouselInner.propTypes = {
+  children: PropTypes.array.isRequired,
+  slideWidth: PropTypes.number,
+  className: PropTypes.string,
+  style: PropTypes.object,
+};
+
+export default CarouselInner;

--- a/utils/getValidIndex/getValidIndex.js
+++ b/utils/getValidIndex/getValidIndex.js
@@ -1,0 +1,19 @@
+const getValidIndex = (index, arrLength, modifier) => {
+  if (index < 0) {
+    if (arrLength % modifier !== 0) {
+      return getValidIndex(index + arrLength, arrLength, modifier);
+    }
+
+    return arrLength + index;
+  } else if (index >= arrLength) {
+    if (arrLength % modifier !== 0) {
+      return getValidIndex(index - arrLength, arrLength, modifier);
+    }
+
+    return index - arrLength;
+  }
+
+  return index;
+};
+
+export default getValidIndex;

--- a/utils/getValidIndex/getValidIndex.test.js
+++ b/utils/getValidIndex/getValidIndex.test.js
@@ -1,0 +1,14 @@
+import getValidIndex from './getValidIndex';
+
+it('returns the same value when given an index that exists', () => {
+  expect(getValidIndex(1, 10, 1)).toBe(1);
+  expect(getValidIndex(2, 10, 1)).toBe(2);
+  expect(getValidIndex(9, 10, 1)).toBe(9);
+});
+
+it('returns a valid index, at the opposite end of the array when given an invalid index', () => {
+  expect(getValidIndex(-1, 10, 1)).toBe(9);
+  expect(getValidIndex(-5, 10, 1)).toBe(5);
+  expect(getValidIndex(10, 10, 1)).toBe(0);
+  expect(getValidIndex(15, 10, 1)).toBe(5);
+});


### PR DESCRIPTION
A simple carousel component with few bells and whistles.
Control from the outside by adding a ref and calling the
instance's `goToIndex`.

Doesn't support swiping or rendering infinite slides. Both
are in the road map however
