### PR TITLE
Fix alias of components in webpack configuration

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -9,6 +9,12 @@ var webpackPostcssTools = require('webpack-postcss-tools');
 var cssMap = webpackPostcssTools.makeVarMap(path.join(paths.globalsSrc, 'index.css'));
 
 module.exports = {
+  resolve: {
+    alias: {
+      // No more relative component imports
+      components: paths.componentSrc,
+    },
+  },
   module: {
     loaders: [
       {

--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -81,7 +81,7 @@ module.exports = {
       // https://www.smashingmagazine.com/2016/08/a-glimpse-into-the-future-with-react-native-for-web/
       'react-native': 'react-native-web',
       // No more relative component imports
-      'components': '../components',
+      components: paths.componentSrc,
     }
   },
   // Resolve loaders (webpack plugins for CSS, images, transpilation) from the

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -74,7 +74,7 @@ module.exports = {
       // https://www.smashingmagazine.com/2016/08/a-glimpse-into-the-future-with-react-native-for-web/
       'react-native': 'react-native-web',
       // No more relative component imports
-      'components': '../components',
+      components: paths.componentSrc,
     }
   },
   // Resolve loaders (webpack plugins for CSS, images, transpilation) from the

--- a/package.json
+++ b/package.json
@@ -97,7 +97,8 @@
     ],
     "moduleNameMapper": {
       "^[./a-zA-Z0-9$_-]+\\.(jpg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm)$": "<rootDir>/config/jest/FileStub.js",
-      "^[./a-zA-Z0-9$_-]+\\.css$": "<rootDir>/config/jest/CSSStub.js"
+      "^[./a-zA-Z0-9$_-]+\\.css$": "<rootDir>/config/jest/CSSStub.js",
+      "^components": "<rootDir>/components"
     },
     "scriptPreprocessor": "<rootDir>/config/jest/transform.js",
     "setupFiles": [


### PR DESCRIPTION
Before we were attempting to allow us to use `components/Component`
as the require path, but it never actually worked. This fixes that
while also adding the functionality to Jest
