### PR TITLE
Make propType warnings throw when testing

### DIFF
--- a/components/Hero/Hero.test.js
+++ b/components/Hero/Hero.test.js
@@ -4,5 +4,5 @@ import Hero from './Hero';
 
 it('renders without crashing', () => {
   const div = document.createElement('div');
-  ReactDOM.render(<Hero />, div);
+  ReactDOM.render(<Hero>requires children</Hero>, div);
 });

--- a/components/Icon/iconHelper.test.js
+++ b/components/Icon/iconHelper.test.js
@@ -7,7 +7,7 @@ import iconHelper from './iconHelper';
 describe('Icon helper', () => {
   it('outputs a valid react component', () => {
     const Icon = iconHelper();
-    expect(isElement(<Icon />)).toBe(true);
+    expect(isElement(<Icon name="" />)).toBe(true);
   });
 });
 
@@ -29,31 +29,7 @@ describe('Icon component', () => {
     const Icon = iconHelper(icons);
     const elm = React.createElement(Icon, { name: incorrectIconName });
     const div = document.createElement('div');
-    let hasThrown = false;
 
-    try {
-      ReactDOM.render(elm, div);
-    } catch (e) {
-      hasThrown = true;
-    }
-
-    expect(hasThrown).toBeTruthy();
-  });
-
-  it('throws when given no icon name', () => {
-    const svg = <svg />;
-    const icons = { icon: svg };
-    const Icon = iconHelper(icons);
-    const elm = React.createElement(Icon);
-    const div = document.createElement('div');
-    let hasThrown = false;
-
-    try {
-      ReactDOM.render(elm, div);
-    } catch (e) {
-      hasThrown = true;
-    }
-
-    expect(hasThrown).toBeTruthy();
+    expect(() => { ReactDOM.render(elm, div) }).toThrow();
   });
 });

--- a/components/Indicators/IndicatorGroup.test.js
+++ b/components/Indicators/IndicatorGroup.test.js
@@ -16,7 +16,12 @@ class TestComp extends Component {
 
 it('renders without crashing', () => {
   const div = document.createElement('div');
-  ReactDOM.render(<IndicatorGroup />, div);
+  ReactDOM.render(
+    <IndicatorGroup>
+      { indicator => indicator({ i: 0 }) }
+    </IndicatorGroup>,
+    div
+  );
 });
 
 it('outputs children of the correct type', () => {

--- a/components/Type/Synopsis/Synopsis.test.js
+++ b/components/Type/Synopsis/Synopsis.test.js
@@ -4,5 +4,5 @@ import Synopsis from './Synopsis';
 
 it('renders without crashing', () => {
   const div = document.createElement('div');
-  ReactDOM.render(<Synopsis />, div);
+  ReactDOM.render(<Synopsis title="" body="" />, div);
 });

--- a/config/jest/setupTestFramework.js
+++ b/config/jest/setupTestFramework.js
@@ -1,0 +1,23 @@
+var util = require('util');
+
+// nobody cares about warnings so lets make them errors
+
+// keep a reference to the original console methods
+var consoleWarn = console.warn;
+var consoleError = console.error;
+
+function logToError() {
+  throw new Error(util.format.apply(this, arguments).replace(/^Error: (?:Warning: )?/, ''));
+}
+
+jasmine.getEnv().beforeEach(function() {
+  // make calls to console.warn and console.error throw an error
+  console.warn = logToError;
+  console.error = logToError;
+});
+
+jasmine.getEnv().afterEach(function() {
+  // return console.warn and console.error to default behaviour
+  console.warn = consoleWarn;
+  console.error = consoleError;
+});

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
       "<rootDir>/(build|docs|node_modules)/"
     ],
     "testEnvironment": "node",
-    "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(js|jsx)$"
+    "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(js|jsx)$",
+    "setupTestFrameworkScriptFile": "<rootDir>/config/jest/setupTestFramework.js"
   }
 }


### PR DESCRIPTION
During testing, any prop type warnings will now cause an error in
your code. This means they act as a first point of failure when
using components in tests, and we're never testing just for props
existing. Also makes the default render without crashing test
give an accurate representation of what props are required
