### PR TITLE
Add RandomSix photo grid component

### DIFF
--- a/components/PhotoGrid/PhotoGrid.story.js
+++ b/components/PhotoGrid/PhotoGrid.story.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import { storiesOf } from '@kadira/storybook';
+
+import RandomSix from './RandomSix';
+
+const images = [{
+  src: 'http://placekitten.com/150/150',
+  alt: '1',
+}, {
+  src: 'http://placekitten.com/297/297',
+  alt: '2',
+}, {
+  src: 'http://placekitten.com/165/136',
+  alt: '3',
+}, {
+  src: 'http://placekitten.com/146/146',
+  alt: '4',
+}, {
+  src: 'http://placekitten.com/298/218',
+  alt: '5',
+}, {
+  src: 'http://placekitten.com/139/139',
+  alt: '6',
+}];
+
+storiesOf('Photo grids', module)
+  .add('<RandomSix />', () => (
+    <RandomSix children={ images } />
+  ));

--- a/components/PhotoGrid/RandomSix.css
+++ b/components/PhotoGrid/RandomSix.css
@@ -1,0 +1,64 @@
+.root * {
+  box-sizing: border-box;
+}
+
+.imageContainer {
+  width: 100%;
+  display: inline-block;
+}
+
+.image {
+  width: 100%;
+  vertical-align: bottom;
+}
+
+.root {
+  max-width: calc(40rem + (var(--size-small) * 4));
+  display: inline-block;
+}
+
+.row + .row {
+  margin-top: var(--size-medium);
+  display: block;
+}
+
+.row + .row .image {
+  vertical-align: top;
+}
+
+.imageContainer {
+  margin-top: 0;
+  margin-left: var(--size-small);
+  margin-right: var(--size-small);
+  display: inline-block;
+  text-align: center;
+  float: none;
+}
+
+.image {
+  width: auto;
+  max-width: 100%;
+}
+
+.imageContainerLeft {
+  width: calc(22.4375% - (var(--size-small) * 2));
+  text-align: right;
+}
+
+.imageContainerCenter {
+  width: calc(45.40625% - (var(--size-small) * 2));
+  text-align: center;
+}
+
+.imageContainerRight {
+  width: calc(24.78125% - (var(--size-small) * 2));
+  text-align: left;
+}
+
+.imageContainer:first-child {
+  margin-left: 0;
+}
+
+.imageContainer:last-child {
+  margin-right: 0;
+}

--- a/components/PhotoGrid/RandomSix.js
+++ b/components/PhotoGrid/RandomSix.js
@@ -1,0 +1,68 @@
+import React, { PropTypes, Children } from 'react';
+import cx from 'classnames';
+
+import m from '../../globals/modifiers.css';
+import css from './RandomSix.css';
+
+const RandomSix = ({ children, className }) => {
+  const {
+    0: one,
+    1: two,
+    2: three,
+    3: four,
+    4: five,
+    5: six
+  } = children;
+
+  return (
+    <div className={ cx(css.root, className) }>
+      <div className={css.row}>
+        <div className={ cx(css.imageContainer, css.imageContainerLeft) }>
+          { one.src && (
+            <img className={ css.image } src={ one.src } alt={ one.alt } />
+          ) }
+        </div>
+        <div className={ cx(css.imageContainer, css.imageContainerCenter) }>
+          { two.src && (
+            <img className={ css.image } src={ two.src } alt={ two.alt } />
+          ) }
+        </div>
+        <div className={ cx(css.imageContainer, css.imageContainerRight) }>
+          { three.src && (
+            <img className={ css.image } src={ three.src } alt={ three.alt } />
+          ) }
+        </div>
+      </div>
+      <div className={css.row}>
+        <div className={ cx(css.imageContainer, css.imageContainerLeft, m.valignt) }>
+          { four.src && (
+            <img className={ css.image } src={ four.src } alt={ four.alt } />
+          ) }
+        </div>
+        <div className={ cx(css.imageContainer, css.imageContainerCenter, m.valignt) }>
+          { five.src && (
+            <img className={ css.image } src={ five.src } alt={ five.alt } />
+          ) }
+        </div>
+        <div className={ cx(css.imageContainer, css.imageContainerRight, m.valignt) }>
+          { six.src && (
+            <img className={ css.image } src={ six.src } alt={ six.alt } />
+          ) }
+        </div>
+      </div>
+    </div>
+
+  );
+};
+
+RandomSix.propTypes = {
+  children: PropTypes.arrayOf(
+    PropTypes.shape({
+      src: PropTypes.string,
+      alt: PropTypes.string,
+    })
+  ).isRequired,
+  className: PropTypes.string,
+};
+
+export default RandomSix;

--- a/components/PhotoGrid/RandomSix.test.js
+++ b/components/PhotoGrid/RandomSix.test.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import { render } from 'react-dom';
+
+import RandomSix from './RandomSix';
+
+it('renders without crashing', () => {
+  const children = [{
+    src: '',
+    alt: '',
+  }, {
+    src: '',
+    alt: '',
+  }, {
+    src: '',
+    alt: '',
+  }, {
+    src: '',
+    alt: '',
+  }, {
+    src: '',
+    alt: '',
+  }, {
+    src: '',
+    alt: '',
+  }];
+
+  const div = document.createElement('div');
+  render(
+    <RandomSix children={children} />,
+    div
+  );
+});


### PR DESCRIPTION
Photo grid which shows the **second** element at small sizes, and then shows
the full grid at ~29rem. Don't want to render one of the items? Simply leave
out the `src` prop. It will preserve the rendering of the rest of the grid
and skip that one space
