### PR TITLE
Btn sizing

### DIFF
--- a/components/Btn/Btn.css
+++ b/components/Btn/Btn.css
@@ -1,5 +1,5 @@
 .root {
-  padding: 0.75rem 2.5rem;
+  padding: var(--size-medium) var(--size-large);
   background-color: var(--color-black);
   color: var(--color-white);
   border-width: 1px;


### PR DESCRIPTION
Button labels were previously [hard] too read, and were too short and fat. Now they're easier to read and a bit more shapely.
