### PR TITLE
Add Tabs component

### DIFF
--- a/components/Tabs/Tab.js
+++ b/components/Tabs/Tab.js
@@ -1,0 +1,73 @@
+import React, { Component, PropTypes } from 'react';
+import cx from 'classnames';
+
+import css from './Tabs.css';
+
+export default class Tab extends Component {
+  static propTypes = {
+    value: PropTypes.number,
+    selected: PropTypes.bool,
+    className: PropTypes.string,
+    children: PropTypes.node,
+    onClick: PropTypes.func,
+    onFocus: PropTypes.func,
+    onBlur: PropTypes.func
+  }
+
+  handleClick = (e) => {
+    const { onClick, value } = this.props;
+    onClick(e, parseInt(value, 10));
+  };
+
+  handleFocus = (e) => {
+    const { onFocus, value } = this.props;
+    onFocus(e, parseInt(value, 10));
+  };
+
+  handleBlur = (e) => {
+    const { onBlur, value } = this.props;
+    onBlur(e, parseInt(value, 10));
+  };
+
+  focus = () => {
+    this.component.focus();
+  };
+
+  blur = () => {
+    this.component.blur();
+  };
+
+  render() {
+    const {
+      value,
+      selected,
+      className,
+      children,
+      ...rest,
+    } = this.props;
+
+    const classes = cx(
+      css.tab,
+      selected ? css.tabActive : null,
+      className
+    );
+
+    return (
+      <button
+        { ...rest }
+        ref={ (c) => {
+          this.component = c;
+        } }
+        onFocus={ this.handleFocus }
+        onBlur={ this.handleBlur }
+        onClick={ this.handleClick }
+        className={ classes }
+        aria-selected= { selected }
+        value={ value }
+        tabIndex={ selected ? 0 : -1 }
+      >
+        { children }
+      </button>
+    );
+  }
+}

--- a/components/Tabs/Tab.test.js
+++ b/components/Tabs/Tab.test.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { Simulate } from 'react-addons-test-utils';
+import Tab from './Tab';
+
+it('renders without crashing', () => {
+  const div = document.createElement('div');
+  ReactDOM.render(
+    <Tab />,
+    div
+  );
+});

--- a/components/Tabs/Tabs.css
+++ b/components/Tabs/Tabs.css
@@ -1,0 +1,58 @@
+.tabs {
+  width: 100%;
+}
+
+.tabsContainer {
+  border-bottom: 1px solid var(--color-greyLighter);
+}
+
+.tab,
+.tab:hover,
+.tab:focus,
+.tab:active {
+  background: transparent;
+  border-color: transparent;
+  color: currentColor;
+}
+
+.tab:focus {
+  outline: var(--color-focusRing) auto 5px;
+}
+
+.tab {
+  padding: 0;
+  margin: 0;
+  font: var(--font-small);
+  vertical-align: top;
+  text-align: left;
+  cursor: pointer;
+  width: auto;
+  padding-top: var(--size-small);
+  padding-bottom: var(--size-small);
+  padding-right: var(--size-medium);
+  margin-right: var(--size-small);
+  text-transform: uppercase;
+  border-width: 0;
+  border-bottom: 2px solid transparent;
+}
+
+.tabActive,
+.tabActive:hover,
+.tabActive:focus,
+.tabActive:active {
+  border-bottom: 2px solid var(--color-black);
+  font-weight: var(--fontweight-demi);
+}
+
+.tabsContent {
+  position: relative;
+  margin-top: var(--size-medium);
+}
+
+.tabContent {
+  display: none;
+}
+
+.tabContentActive {
+  display: block;
+}

--- a/components/Tabs/Tabs.js
+++ b/components/Tabs/Tabs.js
@@ -1,0 +1,135 @@
+import React, {
+  Component,
+  PropTypes,
+  Children,
+  cloneElement,
+} from 'react';
+
+import uniqueId from 'lodash/fp/uniqueId';
+
+import cx from 'classnames';
+import invariant from 'invariant';
+
+import ScreenReadable from '../ScreenReadable/ScreenReadable';
+import keyboardHandler from './tabKeyboardHandler';
+import css from './Tabs.css';
+
+/**
+ * Taken heavy influence from http://codepen.io/svinkle/pen/edmDF?editors=0010
+ * for a11y
+ */
+export default class Tabs extends Component {
+  static propTypes = {
+    accessibilityDescription: PropTypes.string,
+    children: PropTypes.node,
+  };
+
+  static defaultProps = {
+    accessibilityDescription: 'Use left and right arrows to navigate between tabs.',
+  };
+
+  constructor(props) {
+    super(props);
+
+    this.id = uniqueId('tabs_');
+  }
+
+  state = {
+    activeTabIndex: 0,
+    focusedTabIndex: null,
+  };
+
+  tabs = {};
+
+  updateTabIndexes = (i) => {
+    this.setState({
+      activeTabIndex: i,
+      focusedTabIndex: i,
+    });
+
+    this.tabs[i].focus();
+  };
+
+  handleClick = (e, i) => {
+    this.updateTabIndexes(i);
+  };
+
+  handleFocus = (e, i) => {
+    this.setState({ focusedTabIndex: i });
+  }
+
+  handleBlur = (e, i) => {
+    this.setState({ focusedTabIndex: null });
+  }
+
+  handleKeyDown = (e) => {
+    const { activeTabIndex } = this.state;
+    const { children } = this.props;
+    const i = keyboardHandler(e.which, activeTabIndex, Children.count(children));
+
+
+    if (i > -1) {
+      e.preventDefault();
+      e.stopPropagation();
+
+      this.updateTabIndexes(i);
+    }
+  }
+
+  render() {
+    const { children, accessibilityDescription } = this.props;
+    const { activeTabIndex } = this.state;
+
+    return (
+      <div className={ css.tabs }>
+        <ScreenReadable>
+          <span id={`${this.id}-description`}>
+            { accessibilityDescription }
+          </span>
+        </ScreenReadable>
+        <div className={ css.tabsContainer }>
+          { Children.map(children, (child, i) => {
+              const id = `${this.id}-${i}-tab`;
+
+              return cloneElement(child, {
+                ref: (c) => { this.tabs[i] = c; },
+                key: id,
+                id: id,
+                value: i,
+                selected: activeTabIndex === i,
+                onClick: this.handleClick,
+                onFocus: this.handleFocus,
+                onBlur: this.handleBlur,
+                onKeyDown: this.handleKeyDown,
+                'aria-controls': `${this.id}-${i}-panel`,
+                'aria-describedby': `${this.id}-description`,
+                role: 'tab',
+              }, child.props.label);
+          }) }
+        </div>
+        <div className={ css.tabsContent }>
+          { Children.map(children, (child, i) => {
+            const id = `${this.id}-${i}-panel`;
+            const classes = cx(
+              css.tabContent,
+              activeTabIndex === i ? css.tabContentActive : null,
+            );
+
+            return (
+              <div
+                key={id}
+                id={id}
+                aria-labelledby={`${this.id}-${i}-tab`}
+                aria-hidden={activeTabIndex !== i}
+                role="tabpanel"
+                className={ classes }
+              >
+                { child.props.children }
+              </div>
+            );
+          }) }
+        </div>
+      </div>
+    );
+  }
+}

--- a/components/Tabs/Tabs.story.js
+++ b/components/Tabs/Tabs.story.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import { storiesOf, action } from '@kadira/storybook';
+
+import Tabs from './Tabs';
+import Tab from './Tab';
+
+
+storiesOf('Tabs', module)
+  .add('Default', () => (
+    <div>
+      <Tabs onChange={ action('Changed tab') }>
+        <Tab label="Sail - AWOLNATION">
+          <iframe width="560" height="315" src="https://www.youtube.com/embed/Awf45u6zrP0" frameborder="0" allowfullscreen />
+        </Tab>
+        <Tab label="Will Sasso">
+          <iframe width="560" height="315" src="https://www.youtube.com/embed/T6i5qHHXjz0" frameborder="0" allowfullscreen />
+        </Tab>
+        <Tab label="Go go Power Rangers!">
+          <iframe width="560" height="315" src="https://www.youtube.com/embed/7Wt6XlVob_E" frameborder="0" allowfullscreen />
+        </Tab>
+      </Tabs>
+    </div>
+  ));

--- a/components/Tabs/Tabs.test.js
+++ b/components/Tabs/Tabs.test.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import Tabs from './Tabs';
+import Tab from './Tab';
+
+it('renders without crashing', () => {
+  const div = document.createElement('div');
+  ReactDOM.render(
+    <Tabs>
+      <Tab />
+    </Tabs>,
+    div
+  );
+});

--- a/components/Tabs/tabKeyboardHandler.js
+++ b/components/Tabs/tabKeyboardHandler.js
@@ -1,0 +1,26 @@
+import getValidIndex from '../../utils/getValidIndex/getValidIndex';
+
+const tabKeyboardHandler = (keyCode, currentIndex, tabsLength) => {
+  switch(keyCode) {
+    // Left/Up
+    case 37:
+    case 38:
+      return getValidIndex(currentIndex - 1, tabsLength, 1);
+    // Right/Down
+    case 39:
+    case 40:
+      return getValidIndex(currentIndex + 1, tabsLength, 1);
+    // Home
+    case 36:
+      return 0;
+    // End
+    case 35:
+      return tabsLength - 1;
+    // Enter/Space
+    case 13:
+    case 32:
+      return currentIndex;
+  }
+}
+
+export default tabKeyboardHandler;

--- a/components/Tabs/tabKeyboardHandler.test.js
+++ b/components/Tabs/tabKeyboardHandler.test.js
@@ -1,0 +1,57 @@
+import tabKeyboardHandler from './tabKeyboardHandler';
+
+it('returns the correct index for a `left` arrow key press', () => {
+  const keyCode = 37;
+  expect(tabKeyboardHandler(keyCode, 0, 3)).toBe(2);
+  expect(tabKeyboardHandler(keyCode, 1, 3)).toBe(0);
+  expect(tabKeyboardHandler(keyCode, 2, 3)).toBe(1);
+});
+
+it('returns the correct index for a `up` arrow key press', () => {
+  const keyCode = 38;
+  expect(tabKeyboardHandler(keyCode, 0, 3)).toBe(2);
+  expect(tabKeyboardHandler(keyCode, 1, 3)).toBe(0);
+  expect(tabKeyboardHandler(keyCode, 2, 3)).toBe(1);
+});
+
+it('returns the correct index for a `right` arrow key press', () => {
+  const keyCode = 39;
+  expect(tabKeyboardHandler(keyCode, 0, 3)).toBe(1);
+  expect(tabKeyboardHandler(keyCode, 1, 3)).toBe(2);
+  expect(tabKeyboardHandler(keyCode, 2, 3)).toBe(0);
+});
+
+it('returns the correct index for a `down` arrow key press', () => {
+  const keyCode = 40;
+  expect(tabKeyboardHandler(keyCode, 0, 3)).toBe(1);
+  expect(tabKeyboardHandler(keyCode, 1, 3)).toBe(2);
+  expect(tabKeyboardHandler(keyCode, 2, 3)).toBe(0);
+});
+
+it('returns the correct index for a `home` key press', () => {
+  const keyCode = 36;
+  expect(tabKeyboardHandler(keyCode, 0, 3)).toBe(0);
+  expect(tabKeyboardHandler(keyCode, 1, 3)).toBe(0);
+  expect(tabKeyboardHandler(keyCode, 2, 3)).toBe(0);
+});
+
+it('returns the correct index for a `end` key press', () => {
+  const keyCode = 35;
+  expect(tabKeyboardHandler(keyCode, 0, 3)).toBe(2);
+  expect(tabKeyboardHandler(keyCode, 1, 3)).toBe(2);
+  expect(tabKeyboardHandler(keyCode, 2, 3)).toBe(2);
+});
+
+it('returns the correct index for a `enter` key press', () => {
+  const keyCode = 13;
+  expect(tabKeyboardHandler(keyCode, 0, 3)).toBe(0);
+  expect(tabKeyboardHandler(keyCode, 1, 3)).toBe(1);
+  expect(tabKeyboardHandler(keyCode, 2, 3)).toBe(2);
+});
+
+it('returns the correct index for a `enter` key press', () => {
+  const keyCode = 32;
+  expect(tabKeyboardHandler(keyCode, 0, 3)).toBe(0);
+  expect(tabKeyboardHandler(keyCode, 1, 3)).toBe(1);
+  expect(tabKeyboardHandler(keyCode, 2, 3)).toBe(2);
+});

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
   "dependencies": {
     "classnames": "^2.2.5",
     "invariant": "^2.2.1",
+    "lodash": "^4.16.3",
     "lost": "^7.1.0",
     "npm-git-install": "^0.2.0",
     "react": "^15.3.2",


### PR DESCRIPTION
A11y friendly tab component(s):
- `<Tabs />` component, for state handling of the current active tab and dealing
  with that props to give the `<Tab />` component.
- `<Tab />` component which accepts a label and children. The label will be what
  actually gets rendered in the tab; the children will become it's accompanying
  body of content when used inside `<Tabs />`. All other props will also be
  given by `<Tabs />`

Inspiration for the a11y friendliness has come from:
http://codepen.io/svinkle/pen/edmDF?editors=0100
