### PR TITLE
Remove webpack alias for `/components`

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -9,12 +9,6 @@ var webpackPostcssTools = require('webpack-postcss-tools');
 var cssMap = webpackPostcssTools.makeVarMap(path.join(paths.globalsSrc, 'index.css'));
 
 module.exports = {
-  resolve: {
-    alias: {
-      // No more relative component imports
-      components: paths.componentSrc,
-    },
-  },
   module: {
     loaders: [
       {

--- a/components/Video/PlayBtn/PlayBtn.js
+++ b/components/Video/PlayBtn/PlayBtn.js
@@ -1,8 +1,8 @@
 import React, { PropTypes } from 'react';
 
-import ScreenReadable from 'components/ScreenReadable/ScreenReadable';
-import BtnContainer from 'components/BtnContainer/BtnContainer';
-import Icon from 'components/Icon/Icon';
+import ScreenReadable from '../../ScreenReadable/ScreenReadable';
+import BtnContainer from '../../BtnContainer/BtnContainer';
+import Icon from '../../Icon/Icon';
 import css from './PlayBtn.css';
 
 const PlayBtn = ({ play, pause, paused }) => {

--- a/components/VideoWithRichPoster/VideoWithRichPoster.js
+++ b/components/VideoWithRichPoster/VideoWithRichPoster.js
@@ -1,12 +1,12 @@
 import React, { Component, PropTypes } from 'react';
 import cx from 'classnames';
 
-import ScreenReadable from 'components/ScreenReadable/ScreenReadable';
-import Controls from 'components/Video/Controls/Controls';
-import PlayBtn from 'components/Video/PlayBtn/PlayBtn';
+import ScreenReadable from '../ScreenReadable/ScreenReadable';
+import Controls from '../Video/Controls/Controls';
+import PlayBtn from '../Video/PlayBtn/PlayBtn';
 import css from './VideoWithRichPoster.css';
-import Video from 'components/Video/Video';
-import Icon from 'components/Icon/Icon';
+import Video from '../Video/Video';
+import Icon from '../Icon/Icon';
 
 export default class VideoWithPoster extends Component {
   static propTypes = {

--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -80,8 +80,6 @@ module.exports = {
       // Support React Native Web
       // https://www.smashingmagazine.com/2016/08/a-glimpse-into-the-future-with-react-native-for-web/
       'react-native': 'react-native-web',
-      // No more relative component imports
-      components: paths.componentSrc,
     }
   },
   // Resolve loaders (webpack plugins for CSS, images, transpilation) from the

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -73,8 +73,6 @@ module.exports = {
       // Support React Native Web
       // https://www.smashingmagazine.com/2016/08/a-glimpse-into-the-future-with-react-native-for-web/
       'react-native': 'react-native-web',
-      // No more relative component imports
-      components: paths.componentSrc,
     }
   },
   // Resolve loaders (webpack plugins for CSS, images, transpilation) from the

--- a/package.json
+++ b/package.json
@@ -98,8 +98,7 @@
     ],
     "moduleNameMapper": {
       "^[./a-zA-Z0-9$_-]+\\.(jpg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm)$": "<rootDir>/config/jest/FileStub.js",
-      "^[./a-zA-Z0-9$_-]+\\.css$": "<rootDir>/config/jest/CSSStub.js",
-      "^components": "<rootDir>/components"
+      "^[./a-zA-Z0-9$_-]+\\.css$": "<rootDir>/config/jest/CSSStub.js"
     },
     "scriptPreprocessor": "<rootDir>/config/jest/transform.js",
     "setupFiles": [


### PR DESCRIPTION
While much nicer to work with, aliases cause issues with including
the library in other projects. Removing them until we have a better
solution (producing a UMD build?) is the best course of action
