### PR TITLE
Make `<Wrapper />` component accept styling from the outside

### DIFF
--- a/components/Wrapper/Wrapper.css
+++ b/components/Wrapper/Wrapper.css
@@ -1,7 +1,14 @@
 .root {
   max-width: 80rem;
-  padding-left: var(--size-large);
-  padding-right: var(--size-large);
   margin-left: auto;
   margin-right: auto;
+  padding-left: var(--size-large);
+  padding-right: var(--size-large);
+}
+
+@media (--wrapper-large) {
+  .root {
+    padding-left: var(--space-48);
+    padding-right: var(--space-48);
+  }
 }

--- a/components/Wrapper/Wrapper.js
+++ b/components/Wrapper/Wrapper.js
@@ -1,7 +1,15 @@
 import React, { PropTypes } from 'react';
+import cx from 'classnames';
 
 import css from './Wrapper.css';
 
-export default ({ children }) => (
-  <div className={ css.root }>{ children }</div>
+const Wrapper = ({ children, className }) => (
+  <div className={ cx(css.root, className) }>{ children }</div>
 );
+
+Wrapper.propTypes = {
+  children: PropTypes.node,
+  className: PropTypes.string,
+};
+
+export default Wrapper;

--- a/globals/breakpoints.css
+++ b/globals/breakpoints.css
@@ -4,4 +4,5 @@
  */
 :root {
   @custom-media --hero-large (min-width: 50rem);
+  @custom-media --wrapper-large (min-width: 62.25rem);
 }


### PR DESCRIPTION
1. `<Wrapper />` now accepts a className prop and consumes it along side its own
   default styles
2. `<Wrapper />` now has increased margins at larger sizes
