### PR TITLE
💤 Add aspectRatio support to video component

### DIFF
--- a/components/Video/Video.css
+++ b/components/Video/Video.css
@@ -1,6 +1,5 @@
 .root {
   position: relative;
-  padding-bottom: 56.25%; /* 16:9 */
   height: 0;
   background-color: var(--color-black);
 }

--- a/components/Video/Video.js
+++ b/components/Video/Video.js
@@ -8,12 +8,16 @@ import PlayBtn from './PlayBtn/PlayBtn';
 import css from './Video.css';
 
 const Video = (props) => {
-  const { children: source, className, controls, ...rest } = props;
+  const { children: source, className, controls, aspectRatio, ...rest } = props;
   const classes = cx(css.root, className);
 
+  // react-html5video needs to support style props for this to work
   return (
     <ReactVideo
       className={ classes }
+      style={ {
+        paddingBottom: `${height}%`,
+      } }
       controls={ controls }
       { ...rest }
     >
@@ -33,10 +37,20 @@ Video.propTypes = {
   ]).isRequired,
   className: PropTypes.string,
   controls: PropTypes.bool,
+  aspectRatio: (props, propName, componentName) => {
+    if (props[propName].indexOf(':') < 0) {
+      return new Error(
+        'Invalid prop `' + propName + '` supplied to' +
+        ' `' + componentName + '`. Invalid format. Aspect ratio should be ' +
+        'supplied like 4:3.'
+      );
+    }
+  }
 };
 
 Video.defaultProps = {
   controls: false,
+  aspectRatio: '16:9',
 };
 
 export default Video;

--- a/components/Video/Video.story.js
+++ b/components/Video/Video.story.js
@@ -4,7 +4,7 @@ import Video from './Video';
 
 storiesOf('Video', module)
   .add('with controls', () => (
-    <Video controls>
+    <Video controls aspectRatio="4:3">
       <source
         src="https://s3-eu-west-1.amazonaws.com/appearhere/assets/bloom/example-video.mp4"
         type="video/mp4"


### PR DESCRIPTION
Unfortunately, this won't actually work right now as the `style` prop isn't used correctly by [`react-html5video`](https://github.com/mderrick/react-html5video/blob/master/src/components/video/Video.js#L363-L370). I'm planning on fixing that shortly however.

In the mean time, to set the aspect ratio of the video, override `padding-bottom` by passing in a `className`.
