### PR TITLE
Clean up GridFader propTypes warning for GridItemComponent

### DIFF
--- a/components/GridFader/GridFader.js
+++ b/components/GridFader/GridFader.js
@@ -18,9 +18,9 @@ export default class GridFader extends Component {
       }),
     ).isRequired,
     GridItemComponent: PropTypes.oneOfType([
-      PropTypes.element,
       PropTypes.string,
-    ]).isRequired,
+      PropTypes.func,
+    ]),
     columnClass: PropTypes.string,
     limit: PropTypes.number,
     swapInterval: PropTypes.number,


### PR DESCRIPTION
Component classes and stateless components are actually functions, not valid React elements or nodes... who knew!
