### PR TITLE
Increase minimum height of Hero component

### DIFF
--- a/components/Hero/Hero.css
+++ b/components/Hero/Hero.css
@@ -6,6 +6,7 @@
   width: 100%;
   height: 100%;
   position: relative;
+  min-height: 88vh;
 }
 
 .inner {
@@ -24,7 +25,6 @@
   display: none;
 }
 
-/* Media query variable support pls */
 @media(--hero-large) {
   .inner {
     padding: var(--space-200) var(--space-200);


### PR DESCRIPTION
Roughly the correct sizing to indicate the need to scroll while taking up as much of the viewport as possible
