### PR TITLE
Implement alternate styling for `<SectionHeader>` with and without strapline

### DIFF
--- a/components/Type/SectionHeader/SectionHeader.css
+++ b/components/Type/SectionHeader/SectionHeader.css
@@ -4,14 +4,28 @@
  */
 .base {
   color: currentColor;
+  display: block;
 }
 
 .title {
   margin-top: 0;
   margin-bottom: 0;
+  font: var(--font-large-iv);
+  letter-spacing: var(--letter-spacing-regular);
+  text-transform: uppercase;
 }
 
 .strapline {
   margin-top: var(--size-medium);
   margin-bottom: 0;
+  font: var(--font-large-iii);
+  font-weight: var(--fontweight-demi);
+}
+
+.titleWithStrapline {
+  text-transform: uppercase;
+  font: var(--font-regular);
+  font-weight: var(--fontweight-demi);
+  letter-spacing: var(--letter-spacing-regular);
+  color: var(--color-greyDark);
 }

--- a/components/Type/SectionHeader/SectionHeader.js
+++ b/components/Type/SectionHeader/SectionHeader.js
@@ -1,33 +1,61 @@
-import React, { PropTypes } from 'react';
+import React, { PropTypes, createElement } from 'react';
 import classnames from 'classnames';
 
-import m from '../../../globals/modifiers.css';
-import css from './SectionHeader.css';
+import defaultCss from './SectionHeader.css';
 
-const titleClasses = classnames(
-  css.base,
-  css.title,
-  m.fontLgIv,
-  m.uppercase,
-);
 
-const straplineClasses = classnames(
-  css.base,
-  css.strapline,
-  m.fontRegular
-);
+const SectionHeader = (props) => {
+  const {
+    title,
+    strapline,
+    className,
+    level,
+    css,
+    ...rest,
+  } = props;
 
-const SectionHeader = ({ title, strapline, className, ...rest }) => (
-  <div className={ className } { ...rest }>
-    <h1 className={ titleClasses }>{ title }</h1>
-    <p className={ straplineClasses }>{ strapline }</p>
-  </div>
-);
+  const titleClasses = classnames(
+    defaultCss.base,
+    strapline ? [defaultCss.titleWithStrapline] : [defaultCss.title],
+    css.title,
+  );
+
+  const straplineClasses = classnames(
+    defaultCss.base,
+    defaultCss.strapline,
+    css.strapline,
+  );
+
+  const titleEl = <span className={ titleClasses }>{ title }</span>;
+  const straplineEl = strapline && <span className={ straplineClasses }>{ strapline }</span>;
+
+  return (
+    createElement(
+      `h${level}`,
+      { className, ...rest },
+      titleEl,
+      straplineEl
+    )
+  );
+};
 
 SectionHeader.propTypes = {
   className: PropTypes.string,
-  title: PropTypes.node,
+  title: PropTypes.node.isRequired,
   strapline: PropTypes.node,
+  level: PropTypes.number,
+  css: PropTypes.shape({
+    title: PropTypes.string,
+    strapline: PropTypes.string,
+  }),
+};
+
+SectionHeader.defaultProps = {
+  level: 1,
+  css: {
+    title: '',
+    strapline: '',
+  },
 };
 
 export default SectionHeader;

--- a/components/Type/SectionHeader/SectionHeader.test.js
+++ b/components/Type/SectionHeader/SectionHeader.test.js
@@ -4,5 +4,5 @@ import SectionHeader from './SectionHeader';
 
 it('renders without crashing', () => {
   const div = document.createElement('div');
-  ReactDOM.render(<SectionHeader />, div);
+  ReactDOM.render(<SectionHeader title="" />, div);
 });

--- a/components/Type/Type.story.js
+++ b/components/Type/Type.story.js
@@ -26,6 +26,12 @@ storiesOf('Type', module)
       title="Bloom: Pattern library"
       strapline="A styleguide & library of React components"
     />
+  )).add('<SectionHeader /> without strapline', () => (
+    <SectionHeader
+      className={[m.pa48, m.center].join(' ')}
+      level={ 2 }
+      title="Bloom: Pattern library"
+    />
   )).add('<Synopsis /> default', () => (
     <Synopsis className={[m.pa48].join(' ')}
       title="Thousands of spaces, for any idea and budget."

--- a/globals/modifiers.css
+++ b/globals/modifiers.css
@@ -212,6 +212,7 @@
 .code.code { font-family: monospace; }
 .underline.underline { text-decoration: underline; }
 .uppercase.uppercase { text-transform: uppercase; }
+.normal.normal { text-transform: none; }
 
 /* Letter spacing */
 .letSpacingLargeV.letSpacingLargeV { letter-spacing: var(--letter-spacing-large-v); }


### PR DESCRIPTION
With strapline (Bloom: Pattern Library is the title)
![screen shot 2016-11-02 at 10 51 25](https://cloud.githubusercontent.com/assets/63597/19926041/5ead66b0-a0ea-11e6-90e9-f409aa79ebfe.png)

Without strapline: 
![screen shot 2016-11-02 at 10 51 37](https://cloud.githubusercontent.com/assets/63597/19926040/5eaada08-a0ea-11e6-9a72-03ab62ce8826.png)