### PR TITLE
Allow Markdown component body color to be styled

### DIFF
--- a/components/Markdown/Markdown.css
+++ b/components/Markdown/Markdown.css
@@ -2,6 +2,11 @@
  * Allow figures to break the grid, so their contents (images) can be bigger
  * and therefore have a greater impact
  */
+
+.root {
+  color: var(--color-greyDarker);
+}
+
 .root > *:not(figure) {
   margin-left: auto;
   margin-right: auto;
@@ -17,7 +22,7 @@
 .root ol,
 .root ul,
 .root blockquote {
-  color: var(--color-greyDarker);
+  color: currentColor;
   font-family: var(--font-avenir);
   font-size: var(--fontsize-regular);
   line-height: var(--lineheight-regular);


### PR DESCRIPTION
Change the colour of the text by providing a `className` which sets the `color` property. This will set **all** text elements to be that colour, including headings, lists, paragraphs and quotes