### PR TITLE
Fix `<SquareHero />` PropTypes

### DIFF
--- a/components/Hero/SquareHero.js
+++ b/components/Hero/SquareHero.js
@@ -50,8 +50,24 @@ const SquareHero = (props) => {
 
 SquareHero.propTypes = {
   children: PropTypes.node.isRequired,
-  image: PropTypes.string.isRequired,
-  alt: PropTypes.string.isRequired,
+  image: (props, propName, descriptiveName, location) => {
+    const name = descriptiveName || 'ANONYMOUS';
+
+    if (!props.videoProps) {
+      const type = typeof props[propName];
+      const expected = 'string';
+
+      if (type !== expected) {
+        return new Error(
+          `Invalid ${location} \`${propName}\` of type \`${type}\` ` +
+          `supplied to \`${name}\`, expected \`${expected}\`.`
+        );
+      }
+    }
+
+    return null;
+  },
+  alt: PropTypes.string,
   className: PropTypes.string,
   css: PropTypes.shape({
     square: PropTypes.string,

--- a/components/Hero/SquareHero.test.js
+++ b/components/Hero/SquareHero.test.js
@@ -2,10 +2,27 @@ import React from 'react';
 import { render } from 'react-dom';
 import SquareHero from './SquareHero';
 
-it('renders without crashing', () => {
+it('renders with an image without crashing', () => {
   const div = document.createElement('div');
   render(
     <SquareHero image="" alt="">
+      requires children
+    </SquareHero>,
+    div
+  );
+});
+
+it('renders with a video without crashing', () => {
+  const div = document.createElement('div');
+  render(
+    <SquareHero
+      videoProps={ {
+        videoClassName: '',
+        posterClassName: '',
+        posterSrc: <source />,
+        videoSrc: <source />,
+      } }
+    >
       requires children
     </SquareHero>,
     div


### PR DESCRIPTION
By requiring an image and an alt tag, we effectively break the component's support for video. This was missed by lack of test coverage, so I've made it have more clever `propType` checking, and included a test for video support.

The new propType check ensures that either a video or an image _must_ be supplied