### PR TITLE
Fix Banner close button not displaying on all devices

### DIFF
--- a/components/Banner/Banner.css
+++ b/components/Banner/Banner.css
@@ -24,6 +24,10 @@
   vertical-align: top;
 }
 
+.icon {
+  display: block;
+}
+
 .success {
   background-color: var(--color-success);
 }

--- a/components/Banner/Banner.js
+++ b/components/Banner/Banner.js
@@ -29,7 +29,7 @@ const Banner = ({ children, className, context, onClose, ...rest }) => (
     </div>
     { onClose && (
       <BtnContainer className={ css.dismissContainer } onClick={ onClose }>
-        <Icon name="cross" />
+        <Icon className={ css.icon } name="cross" />
       </BtnContainer>
     ) }
   </div>


### PR DESCRIPTION
Seems that Safari doesn't size the cross SVG correctly unless it's a block element. I assume this is because how it calculates the width of the parent element which has `display: table-cell` and a width of `1%`.

**Before**

<img width="691" alt="screen shot 2016-12-23 at 09 36 52" src="https://cloud.githubusercontent.com/assets/2162181/21450994/9b3a7f4c-c8f3-11e6-856d-b5e39f4235e8.png">

**After**

<img width="691" alt="screen shot 2016-12-23 at 09 36 59" src="https://cloud.githubusercontent.com/assets/2162181/21451002/9e056a48-c8f3-11e6-8d68-7714e1c9610d.png">
