### PR TITLE
Match Hero max width to Wrapper's for more consistent layouts

### DIFF
--- a/components/Hero/Hero.css
+++ b/components/Hero/Hero.css
@@ -40,7 +40,6 @@
   width: 100%;
 }
 
-
 .backgroundImage .overlay {
   background-color: rgba(0, 0, 0, 0.5);
 }
@@ -77,6 +76,13 @@
 
 .caption {
   display: none;
+}
+
+@media (--wrapper-large) {
+  .inner {
+    padding-left: var(--space-48);
+    padding-right: var(--space-48);
+  }
 }
 
 @media(--hero-width-lg-i) {


### PR DESCRIPTION
Ensures the padding at the edge if the hero's "inner" (i.e., the content) matches that of `<Wrapper />` so that hero content is always aligned with the rest of the page