### PR TITLE
Stop EventCard call-to-action from also triggering the card's link

### DIFF
--- a/components/Cards/EditorialCard/EventCard.js
+++ b/components/Cards/EditorialCard/EventCard.js
@@ -38,6 +38,13 @@ class EventCard extends Component {
     ctaLabel: 'Get tickets',
   };
 
+  handleBtnClick = (e) => {
+    e.stopPropagation();
+    e.preventDefault();
+
+    this.props.ctaCallback(e);
+  };
+
   render() {
     const {
       description,
@@ -46,7 +53,7 @@ class EventCard extends Component {
       ctaLabel,
       containerQuery,
       className,
-      ctaCallback,
+      ctaCallback: _ctaCallback,
       ...rest,
     } = this.props;
 
@@ -60,7 +67,7 @@ class EventCard extends Component {
           <p className={ css.description }>{ description }</p>
           <span
             className={ cx(css.link, linkcss.root) }
-            onClick={ ctaCallback }
+            onClick={ this.handleBtnCliock }
             tabIndex="0"
             role="button"
           >

--- a/components/Cards/EditorialCard/GuideCard.js
+++ b/components/Cards/EditorialCard/GuideCard.js
@@ -65,6 +65,7 @@ class GuideCard extends Component {
       containerQuery,
       className,
       unlockCallback: _unlockCallback,
+      downloadCallback: _downloadCallback,
       ...rest,
     } = this.props;
 


### PR DESCRIPTION
A `click` event on the call-to-action currently bubble up it the parent anchor and therefore follow it's link. Wrapping the `ctaCallback` and adding calls to `stopPropagation` and `preventDefault` prevents this from happening