### PR TITLE
Ensure `<Hero />` content follows the same max-width as `<Wrapper />`

### DIFF
--- a/components/Hero/Hero.css
+++ b/components/Hero/Hero.css
@@ -57,9 +57,19 @@
 .inner {
   display: table-cell;
   width: 100%;
-  padding: var(--space-96) var(--size-large);
+  padding-top: var(--space-96);
+  padding-bottom: var(--space-96);
   vertical-align: middle;
   text-align: center;
+}
+
+.content {
+  max-width: 80rem;
+  margin-left: auto;
+  margin-right: auto;
+  width: 100%;
+  padding-left: var(--size-large);
+  padding-right: var(--size-large);
 }
 
 .animate .inner {
@@ -79,7 +89,7 @@
 }
 
 @media (--wrapper-large) {
-  .inner {
+  .content {
     padding-left: var(--space-48);
     padding-right: var(--space-48);
   }

--- a/components/Hero/Hero.js
+++ b/components/Hero/Hero.js
@@ -52,7 +52,9 @@ const Hero = (props) => {
 
       <div className={ overlayCl }>
         <div className={ innerCl }>
-          { children }
+          <div className={ css.content }>
+            { children }
+          </div>
         </div>
 
         { caption && backgroundImage && (


### PR DESCRIPTION
Simply adding `padding` to the inner, as per the last attempt at this didn't work quite as expected, neither did supplying a `max-width` via the `innerClassName` prop, as `max-width` doesn't work on elements with `display: table-cell`.

We now wrap a `<Hero />`'s content another level in order to force the `max-width` and correctly handle the `padding` for the content. It now directly reflects how `<Wrapper />` works.