### PR TITLE
Reenable browser default focus styles on `<Input />` component

### DIFF
--- a/components/Forms/Input/Input.css
+++ b/components/Forms/Input/Input.css
@@ -33,9 +33,8 @@ textarea.input {
 }
 
 .focus {
-  border-color: var(--color-greyDarker);
-  color: var(--color-greyDarker);
-  outline: none;
+  border-color: var(--color-greyDark);
+  color: var(--color-greyDark);
 }
 
 .error {


### PR DESCRIPTION
#158 made it apparent that we've maliciously disabled good focus styles for the user. This sets it back to the browser default until a time comes where we may want to consider a viable alternative