### PR TITLE
Add `<Badge />` component

### DIFF
--- a/components/Badge/Badge.css
+++ b/components/Badge/Badge.css
@@ -1,0 +1,41 @@
+.root {
+  display: inline-block;
+  padding-top: var(--size-micro);
+  padding-bottom: var(--size-micro);
+  padding-left: var(--size-small);
+  padding-right: var(--size-small);
+  background-color: var(--color-greyLighter);
+  color: var(--color-grey);
+  border: 1px solid var(--color-greyLighter);
+  composes: fontSmallIi from '../../globals/typography.css';
+  text-transform: uppercase;
+  font-weight: var(--fontweight-demi);
+  border-radius: 3px;
+}
+
+.primary {
+  border: 1px solid var(--color-primary);
+  background-color: var(--color-primary);
+  color: var(--color-white);
+}
+
+.special {
+  border: 1px solid var(--color-black);
+  background-color: var(--color-black);
+  color: var(--color-white);
+}
+
+.hollow {
+  background-color: transparent;
+  border-color: currentColor;
+}
+
+.hollow.primary {
+  color: var(--color-primary);
+  border-color: currentColor;
+}
+
+.hollow.special {
+  color: var(--color-black);
+  border-color: currentColor;
+}

--- a/components/Badge/Badge.js
+++ b/components/Badge/Badge.js
@@ -1,0 +1,27 @@
+import React, { PropTypes } from 'react';
+import cx from 'classnames';
+
+import css from './Badge.css';
+
+const Badge = ({ className, children, context, hollow, ...rest }) => (
+  <span
+    { ...rest }
+    className={ cx(
+      css.root,
+      css[context],
+      hollow ? css.hollow : null,
+      className
+    ) }
+  >
+    { children }
+  </span>
+);
+
+Badge.propTypes = {
+  className: PropTypes.string,
+  children: PropTypes.any,
+  context: PropTypes.oneOf(['primary', 'special']),
+  hollow: PropTypes.bool,
+};
+
+export default Badge;

--- a/components/Badge/Badge.story.js
+++ b/components/Badge/Badge.story.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import { storiesOf } from '@kadira/storybook';
+import Badge from './Badge';
+
+storiesOf('Badge', module)
+  .add('Default badge', () => (
+    <Badge>Soon</Badge>
+  ))
+  .add('Primary badge', () => (
+    <Badge context="primary">New</Badge>
+  ))
+  .add('Special badge', () => (
+    <Badge context="special">Verified</Badge>
+  ))
+  .add('Hollow badge', () => (
+    <Badge hollow>Unknown</Badge>
+  ))
+  .add('Primary hollow badge', () => (
+    <Badge context="primary" hollow>Place</Badge>
+  ))
+  .add('Special hollow badge', () => (
+    <Badge context="special" hollow>Collection</Badge>
+  ));

--- a/components/Badge/Badge.test.js
+++ b/components/Badge/Badge.test.js
@@ -1,0 +1,9 @@
+import React from 'react';
+import { render } from 'react-dom';
+
+import Badge from './Badge';
+
+it('renders without crashing', () => {
+  const div = document.createElement('div');
+  render(<Badge>label</Badge>, div);
+});


### PR DESCRIPTION
Provide additional context to other elements with badges. Works similar
to our `<Btn />` component in that it accepts a context, and can be
toggled to be hollow or not