### PR TITLE
Prevent changing tabs from submitting forms

### DIFF
--- a/components/Tabs/Tab.js
+++ b/components/Tabs/Tab.js
@@ -58,6 +58,7 @@ export default class Tab extends Component {
         ref={ (c) => {
           this.component = c;
         } }
+        type="button"
         onFocus={ this.handleFocus }
         onBlur={ this.handleBlur }
         onClick={ this.handleClick }


### PR DESCRIPTION
When using the `[Tabs]` component inside a form, switching tabs causes the form to submit. 

Can't think why `type` would be anything other than `button`.