### PR TITLE
Fix the map box marker event propagation

### DIFF
--- a/components/Map/BaseMap.css
+++ b/components/Map/BaseMap.css
@@ -3,18 +3,42 @@
 }
 
 .map {
+  composes: fontSmallIi from '../../globals/typography.css';
   overflow: hidden;
   position: relative;
-  -webkit-tap-highlight-color: rgba(0,0,0,0);
-  composes: fontSmallIi from '../../globals/typography.css';
+  -webkit-tap-highlight-color: rgba(0, 0, 0 , 0);
 }
 
-.map :global(.mapboxgl-ctrl-bottom-right) { position:absolute; pointer-events:none; z-index:2; }
-.map :global(.mapboxgl-ctrl-bottom-right) { right:0; bottom:0; }
+.map :global(.mapboxgl-canvas-container) {
+  z-index: var(--z-mapCanvas);
+  position: absolute;
+}
 
-.map :global(.mapboxgl-ctrl) { clear:both; pointer-events:auto }
-.map :global(.mapboxgl-ctrl-bottom-right .mapboxgl-ctrl) { margin:0 10px 10px 0; float:right; }
+.map :global(.mapboxgl-marker-container) {
+  z-index: var(--z-mapMarker);
+  position: absolute;
+}
 
+/* controls */
+.map :global(.mapboxgl-ctrl-bottom-right) {
+  position: absolute;
+  pointer-events: none;
+  z-index: var(--z-mapControls);
+}
+.map :global(.mapboxgl-ctrl-bottom-right) {
+  right: 0;
+  bottom: 0;
+}
+.map :global(.mapboxgl-ctrl) {
+  clear: both;
+  pointer-events: auto
+}
+.map :global(.mapboxgl-ctrl-bottom-right .mapboxgl-ctrl) {
+  margin: 0 10px 10px 0;
+  float: right;
+}
+
+/* attribution */
 .map :global(.mapboxgl-ctrl.mapboxgl-ctrl-attrib) {
   padding: 0 5px;
   background-color: rgba(255, 255, 255, .5);
@@ -25,7 +49,7 @@
   text-decoration: none;
 }
 .map :global(.mapboxgl-ctrl-attrib a):hover {
-    color: inherit;
+  color: inherit;
 }
 .map :global(.mapboxgl-ctrl-attrib .mapbox-improve-map) {
   font-weight: bold;

--- a/globals/z-index.css
+++ b/globals/z-index.css
@@ -23,4 +23,7 @@
   /* Aliases */
   --z-stickyNode: var(--z-5);
   --z-tooltip: var(--z-3);
+  --z-mapCanvas: var(--z-1);
+  --z-mapMarker: var(--z-2);
+  --z-mapControls: var(--z-3);
 }

--- a/utils/mapboxgl/mapboxgl.js
+++ b/utils/mapboxgl/mapboxgl.js
@@ -1,7 +1,57 @@
+/* global window:true */
 import { canUseDOM } from 'exenv';
 
 const mapboxgl = canUseDOM ? require('mapbox-gl/dist/mapbox-gl') : {};
 
 mapboxgl.accessToken = 'pk.eyJ1IjoiYXBwZWFyaGVyZSIsImEiOiJvUlJ0MWxNIn0.8_mzlmxdekKy99luyV4T7w';
+
+const create = (tagName, className, container) => {
+  if (!canUseDOM) return {};
+
+  const el = window.document.createElement(tagName);
+  if (className) el.className = className;
+  if (container) container.appendChild(el);
+  return el;
+};
+
+/* eslint-disable no-underscore-dangle */
+class MapWithMarkerContainer extends mapboxgl.Map {
+  _setupContainer() {
+    super._setupContainer();
+
+    const container = this.getContainer();
+    this.markerContainer = create('div', 'mapboxgl-marker-container', container);
+  }
+
+  getMarkerContainer() {
+    return this.markerContainer;
+  }
+}
+
+// addTo function taken from version 0.33.0
+// https://github.com/mapbox/mapbox-gl-js/blob/adef501c464d51b328bdcdea355008aea9ab8ae1/src/ui/marker.js#L33-L52
+class Marker extends mapboxgl.Marker {
+  /**
+     * Attaches the marker to a map
+     * @param {Map} map
+     * @returns {Marker} `this`
+     */
+  addTo(map) {
+    this.remove();
+    this._map = map;
+    map.getMarkerContainer().appendChild(this._element);
+    map.on('move', this._update);
+    map.on('moveend', this._update);
+    this._update();
+
+    this._map.on('click', this._onMapClick);
+
+    return this;
+  }
+}
+/* eslint-enable no-underscore-dangle */
+
+mapboxgl.Map = MapWithMarkerContainer;
+mapboxgl.Marker = Marker;
 
 export default mapboxgl;


### PR DESCRIPTION
This commit places mapbox markers in their own div, instead of
being added as siblings to the canvas.

This fixes the event ordering issues and allows us to prevent
propagation from the markers to the map

ideally we want to PR this into Mapbox-gl, but this will work as an interim fix