### PR TITLE
Fix the map box marker event propagation

### DIFF
--- a/components/Map/BaseMap.css
+++ b/components/Map/BaseMap.css
@@ -3,17 +3,39 @@
 }
 
 .map {
+  composes: fontSmallIi from '../../globals/typography.css';
   overflow: hidden;
   position: relative;
-  -webkit-tap-highlight-color: rgba(0,0,0,0);
-  composes: fontSmallIi from '../../globals/typography.css';
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
 }
 
-.map :global(.mapboxgl-ctrl-bottom-right) { position:absolute; pointer-events:none; z-index:2; }
-.map :global(.mapboxgl-ctrl-bottom-right) { right:0; bottom:0; }
+.map :global(.mapboxgl-canvas-container) {
+  z-index: var(--z-mapCanvas);
+  position: absolute;
+}
 
-.map :global(.mapboxgl-ctrl) { clear:both; pointer-events:auto }
-.map :global(.mapboxgl-ctrl-bottom-right .mapboxgl-ctrl) { margin:0 10px 10px 0; float:right; }
+.map :global(.mapboxgl-marker-container) {
+  z-index: var(--z-mapMarker);
+  position: absolute;
+}
+
+.map :global(.mapboxgl-ctrl-bottom-right) {
+  position: absolute;
+  pointer-events: none;
+  z-index: var(--z-mapControls);
+}
+.map :global(.mapboxgl-ctrl-bottom-right) {
+  right: 0;
+  bottom: 0;
+}
+.map :global(.mapboxgl-ctrl) {
+  clear: both;
+  pointer-events: auto
+}
+.map :global(.mapboxgl-ctrl-bottom-right .mapboxgl-ctrl) {
+  margin: 0 10px 10px 0;
+  float: right;
+}
 
 .map :global(.mapboxgl-ctrl.mapboxgl-ctrl-attrib) {
   padding: 0 5px;
@@ -25,7 +47,7 @@
   text-decoration: none;
 }
 .map :global(.mapboxgl-ctrl-attrib a):hover {
-    color: inherit;
+  color: inherit;
 }
 .map :global(.mapboxgl-ctrl-attrib .mapbox-improve-map) {
   font-weight: bold;

--- a/globals/z-index.css
+++ b/globals/z-index.css
@@ -25,4 +25,7 @@
   --z-floatingActionBtn: var(--z-6);
   --z-stickyNode: var(--z-5);
   --z-tooltip: var(--z-3);
+  --z-mapCanvas: var(--z-1);
+  --z-mapMarker: var(--z-2);
+  --z-mapControls: var(--z-3);
 }

--- a/utils/mapboxgl/mapboxgl.js
+++ b/utils/mapboxgl/mapboxgl.js
@@ -1,7 +1,60 @@
 import { canUseDOM } from 'exenv';
 
-const mapboxgl = canUseDOM ? require('@appearhere/mapbox-gl/dist/mapbox-gl') : {};
+const createAndAppendChild = (tagName, className, container) => {
+  if (!canUseDOM) return {};
 
-mapboxgl.accessToken = 'pk.eyJ1IjoiYXBwZWFyaGVyZSIsImEiOiJvUlJ0MWxNIn0.8_mzlmxdekKy99luyV4T7w';
+  const el = document.createElement(tagName);
+  if (className) el.className = className;
+  if (container) container.appendChild(el);
+  return el;
+};
 
-export default mapboxgl;
+const monkeyPatchMapbox = (mapbox) => {
+  /* eslint-disable no-underscore-dangle */
+  class Map extends mapbox.Map {
+    _setupContainer() {
+      super._setupContainer();
+
+      const container = this.getContainer();
+      this.markerContainer = createAndAppendChild('div', 'mapboxgl-marker-container', container);
+    }
+
+    getMarkerContainer() {
+      return this.markerContainer;
+    }
+  }
+
+  /**
+   * addTo function taken from version 0.33.0
+   * https://github.com/mapbox/mapbox-gl-js/blob/adef501c464d51b328bdcdea355008aea9ab8ae1/src/ui/marker.js#L33-L52
+   */
+  class Marker extends mapbox.Marker {
+    /**
+     * Attaches the marker to a map
+     * @param {Map} map
+     * @returns {Marker} `this`
+     */
+    addTo(map) {
+      this.remove();
+      this._map = map;
+      map.getMarkerContainer().appendChild(this._element);
+      map.on('move', this._update);
+      map.on('moveend', this._update);
+      this._update();
+
+      this._map.on('click', this._onMapClick);
+
+      return this;
+    }
+  }
+  /* eslint-enable no-underscore-dangle */
+
+  return Object.assign(mapbox, { Map, Marker });
+};
+
+
+const mapbox = canUseDOM ? monkeyPatchMapbox(require('@appearhere/mapbox-gl/dist/mapbox-gl')) : {};
+
+mapbox.accessToken = 'pk.eyJ1IjoiYXBwZWFyaGVyZSIsImEiOiJvUlJ0MWxNIn0.8_mzlmxdekKy99luyV4T7w';
+
+export default mapbox;


### PR DESCRIPTION
2nd attempt: fixed server rendering issues by only attempting to monkey patch mapbox in a browser environment.

The server error:
> Super expression must either be null or a function, not undefined

The error was happening on the server as the monkey patch was being attempted even after we set mapbox to be an empty object:

```javascript
const mapboxgl = canUseDOM ? require('@appearhere/mapbox-gl/dist/mapbox-gl') : {};

// on the server
mapboxgl.Map === undefined
```