### PR TITLE
Stop opening a modal window scrolling the user to the bottom of the page

### DIFF
--- a/components/Modal/ModalAnimator.css
+++ b/components/Modal/ModalAnimator.css
@@ -1,6 +1,7 @@
 .root {
   position: fixed;
   height: 100%;
+  max-height: 100vh;
   width: 100%;
   top: 0;
   left: 0;
@@ -15,8 +16,6 @@
 
 .overlay {
   position: fixed;
-  width: 100%;
-  height: 100%;
   background-color: var(--overlay-default);
   transition: all 200ms;
   top: 0;

--- a/components/Modal/ModalAnimator.js
+++ b/components/Modal/ModalAnimator.js
@@ -152,7 +152,6 @@ export default class ModalAnimator extends Component {
                     aria-describedby={ describedBy }
                   >
                     <div
-                      className={ css.window }
                       className={ cx(css.window, windowClassName) }
                       ref={ (c) => { this.modalWindow = c; } }
                     >

--- a/components/Modal/Window.css
+++ b/components/Modal/Window.css
@@ -9,11 +9,11 @@
 }
 
 .body {
-  padding: var(--size-medium);
+  max-height: calc(100vh - 66px);
   border-top-right-radius: 4px;
   border-top-left-radius: 4px;
   overflow-y: scroll;
-  max-height: 100vh;
+  -webkit-overflow-scrolling: touch;
   padding: var(--size-large);
   clear: both;
 }

--- a/utils/BodyClassNameConductor/BodyClassNameConductor.css
+++ b/utils/BodyClassNameConductor/BodyClassNameConductor.css
@@ -1,3 +1,8 @@
 .noScroll {
   overflow: hidden;
+  position: fixed;
+  height: 0;
+  width: 100%;
+  top: 0;
+  -webkit-overflow-scrolling: auto;
 }


### PR DESCRIPTION
Prevents the activation of a modal window, where the page's body is vertically bigger than the viewport, causing the window to scroll to the bottom of the page. 

A caveat of this is it requires us to set the body to `position: fixed` which will force the user to the *top* of the page instead:

![modal](https://cloud.githubusercontent.com/assets/2162181/24261528/2c10262e-0fef-11e7-9d27-8d89dfc0af7a.gif)

While this isn't ideal, it's much less jarring than the current scenario, and is a good improvement without sinking too much time into it.

It also prevents the user from scrolling the body while the modal is active and stops the modal from being hidden by iOS Safari's browser chrome