### PR TITLE
Make `<InputRange />` & `<InputRangeWithHistogram />` render consistently

### DIFF
--- a/components/Form/InputRange/InputRange.css
+++ b/components/Form/InputRange/InputRange.css
@@ -84,7 +84,7 @@
   background-color: var(--color-greyLight);
 }
 
-.inputRange {
+.input {
   position: absolute;
   width: 100%;
   bottom: calc((-1 * var(--size-large) + calc(-1 * var(--inputRange-track-height))))

--- a/components/Form/InputRange/InputRange.js
+++ b/components/Form/InputRange/InputRange.js
@@ -77,18 +77,20 @@ export default class InputRange extends Component {
     const defaultValue = typeof value === 'object' ? { minValue, maxValue } : maxValue;
 
     return (
-      <ReactInputRange
-        { ...rest }
-        classNames={ classNames }
-        id={ id }
-        value={ value }
-        defaultValue={ defaultValue }
-        onChange={ this.handleChange }
-        onChangeComplete={ this.handleChangeComplete }
-        minValue={ minValue }
-        maxValue={ maxValue }
-        showLabel={ false }
-      />
+      <div className={ css.container }>
+        <ReactInputRange
+          { ...rest }
+          classNames={ classNames }
+          id={ id }
+          value={ value }
+          defaultValue={ defaultValue }
+          onChange={ this.handleChange }
+          onChangeComplete={ this.handleChangeComplete }
+          minValue={ minValue }
+          maxValue={ maxValue }
+          showLabel={ false }
+        />
+      </div>
     );
   }
 }

--- a/components/Form/InputRange/InputRangeWithHistogram.js
+++ b/components/Form/InputRange/InputRangeWithHistogram.js
@@ -50,9 +50,7 @@ export default class InputRangeWithHistogram extends Component {
             </div>
           )) }
         </div>
-        <div className={ css.inputRange }>
-          <InputRange name={ name } { ...rest } />
-        </div>
+        <InputRange name={ name } { ...rest } />
       </div>
     );
   }


### PR DESCRIPTION
Before, content would flow around `<InputRange />` as you would expect. `<InputRangeWithHistogram />` however would act slightly differently due to the range input's `position: absolute` styling. This makes the behaviour consistent, opting to match the latter behaviour as it is somewhat unavoidable given the implementation of the histogram