### PR TITLE
Allow `<AreaUnits />` to accept a string value

### DIFF
--- a/components/AreaUnits/AreaUnits.js
+++ b/components/AreaUnits/AreaUnits.js
@@ -26,7 +26,10 @@ const AreaUnits = ({ value, unit, className, ...rest }) => {
 };
 
 AreaUnits.propTypes = {
-  value: PropTypes.number.isRequired,
+  value: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.string,
+  ]).isRequired,
   unit: PropTypes.string.isRequired,
   className: PropTypes.string,
 };


### PR DESCRIPTION
`<AreaUnits />`'s propTypes currently dictates that the `value` prop can
only be of type `number`. This is inflexible as we have multiple use
cases for the addition of a `+` on the end of the value. This change
allows the the component to accept a string also