### PR TITLE
Make `<Input />`'s avoid framework style leakage

### DIFF
--- a/components/Form/Input/Input.css
+++ b/components/Form/Input/Input.css
@@ -47,9 +47,15 @@ textarea.input {
   min-height: 5rem;
 }
 
-.focus {
-  border-color: var(--color-greyDark);
-  color: var(--color-greyDark);
+input.input[type='text']:focus,
+input.input[type='email']:focus,
+input.input[type='password']:focus,
+input.input[type='search']:focus,
+input.input[type='url']:focus,
+textarea.input:focus {
+  border-color: var(--color-grey);
+  background-color: var(--color-white);
+  color: var(--color-greyDarker);
 }
 
 .error {


### PR DESCRIPTION
Foundation/bootstrap appear to be overriding out own input's style. This increases the level of specificity to avoid any style leakage. It also allows for other components to import the styles and use them without focus state management:

While the input itself manages it's internal focus state and can apply the class through that, under the circumstance where we need to import the input styles and use them else where, we lose the focus styles.

Our first use case for this, is using our styles with the auto complete, which, despite the docs not stating this fact, [requires the input to be stateless](https://github.com/moroshko/react-autosuggest#renderInputComponentProp)