### PR TITLE
Stop `<Modal />`s, with overflow, from sticking when scrolling

### DIFF
--- a/components/Modal/Modal.story.js
+++ b/components/Modal/Modal.story.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { storiesOf, action } from '@kadira/storybook';
-import { withKnobs, boolean, number } from '@kadira/storybook-addon-knobs';
+import { withKnobs, boolean } from '@kadira/storybook-addon-knobs';
 import ModalAnimator from './ModalAnimator';
 import Window from './Window';
 import WithTitleBar from './WithTitleBar';
@@ -260,47 +260,5 @@ stories
           }
         </p>
       </WithActionBar>
-    </ModalAnimator>
-  ))
-  .add('Configurable springs', () => (
-    <ModalAnimator
-      active={ boolean('active', false) }
-      windowSpringConfig={ {
-        stiffness: number('Window spring', 300),
-        damping: number('Window damping', 30),
-      } }
-      overlaySpringConfig={ {
-        stiffness: number('overlay spring', 300),
-        damping: number('overlay damping', 15),
-      } }
-    >
-      <Window onClose={ action('Closing') }>
-        <p className={ [m.fontRegular, m.fgGreyDarker, m.mt0, m.mbm].join(' ') }>
-          {
-            'Aliquam consequat consequat pharetra. Proin sagittis quis ipsum maximus laoreet.' +
-            ' Maecenas condimentum nisl vel lectus vehicula dapibus. Nunc suscipit suscipit leo,' +
-            ' at molestie nibh ultrices quis. Integer mattis enim est, eget interdum magna' +
-            ' facilisis sed. Pellentesque vehicula eget ligula in dapibus. In vel neque sed' +
-            ' lacus sollicitudin viverra. Vestibulum lacinia quam dictum finibus tristique.' +
-            ' Cras vel eros id dolor posuere tempor nec id lectus. Pellentesque eleifend neque' +
-            ' diam, eget luctus diam volutpat nec. In arcu nisl, semper sed pellentesque ut,' +
-            ' vulputate vel ante. Nulla iaculis ligula sit amet nulla sollicitudin, in iaculis' +
-            ' libero sodales.'
-          }
-        </p>
-        <p className={ [m.fontRegular, m.fgGreyDarker, m.mt0, m.mbm].join(' ') }>
-          {
-            'Aliquam consequat consequat pharetra. Proin sagittis quis ipsum maximus laoreet.' +
-            ' Maecenas condimentum nisl vel lectus vehicula dapibus. Nunc suscipit suscipit leo,' +
-            ' at molestie nibh ultrices quis. Integer mattis enim est, eget interdum magna' +
-            ' facilisis sed. Pellentesque vehicula eget ligula in dapibus. In vel neque sed' +
-            ' lacus sollicitudin viverra. Vestibulum lacinia quam dictum finibus tristique.' +
-            ' Cras vel eros id dolor posuere tempor nec id lectus. Pellentesque eleifend neque' +
-            ' diam, eget luctus diam volutpat nec. In arcu nisl, semper sed pellentesque ut,' +
-            ' vulputate vel ante. Nulla iaculis ligula sit amet nulla sollicitudin, in iaculis' +
-            ' libero sodales.'
-          }
-        </p>
-      </Window>
     </ModalAnimator>
   ));

--- a/components/Modal/ModalAnimator.css
+++ b/components/Modal/ModalAnimator.css
@@ -17,45 +17,33 @@
 .overlay {
   position: fixed;
   background-color: var(--overlay-default);
-  transition: all 200ms;
   top: 0;
   left: 0;
   right: 0;
   bottom: 0;
-  will-change: opacity;
-  backface-visibility: hidden;
+  animation-name: fadeIn;
+  animation-iteration-count: 1;
+  animation-fill-mode: forwards;
+  animation-duration: 300ms;
+  animation-timing-function: var(--animation-sharp);
 }
 
 .wrapper {
   position: fixed;
   height: 100%;
   width: 100%;
-  will-change: transform;
-  backface-visibility: hidden;
+  animation-name: fadeIn;
+  animation-iteration-count: 1;
+  animation-fill-mode: forwards;
+  animation-duration: 350ms;
+  animation-timing-function: var(--animation-sharp);
 }
 
-.window {
-  position: fixed;
-  left: 50%;
-  bottom: 0;
-  width: 100%;
-  transform: translate3d(-50%, 0, 0);
-  background-color: var(--color-white);
-  overflow: hidden;
-  max-height: 100vh;
-  border-top-right-radius: 4px;
-  border-top-left-radius: 4px;
-}
-
-@media(--modal-lg) {
-  .window {
-    width: 94vw;
-    max-height: 94vh;
-    max-width: 37.5rem;
-    left: 50%;
-    top: 50%;
-    bottom: auto;
-    transform: translate3d(-50%, -50%, 0);
-    border-radius: 4px;
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
   }
 }

--- a/components/Modal/Window.css
+++ b/components/Modal/Window.css
@@ -8,12 +8,38 @@
   color: var(--color-white);
 }
 
-.body {
-  max-height: calc(100vh - 66px);
-  border-top-right-radius: 4px;
-  border-top-left-radius: 4px;
-  overflow-y: scroll;
+.root {
+  position: fixed;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  width: 100%;
+  height: 100%;
   -webkit-overflow-scrolling: touch;
-  padding: var(--size-large);
   clear: both;
+  z-index: var(--z-modal);
+}
+
+@media(--modal-lg) {
+  .root {
+    width: 94vw;
+    max-height: 94vh;
+    max-width: 37.5rem;
+    height: auto;
+    left: 50%;
+    top: 50%;
+    bottom: auto;
+    transform: translate3d(-50%, -50%, 0);
+    border-radius: 4px;
+  }
+}
+
+.body {
+  width: 100%;
+  height: 100%;
+  max-height: 94vh;
+  padding: var(--size-large);
+  overflow-x: hidden;
+  overflow-y: scroll;
 }

--- a/components/Modal/Window.js
+++ b/components/Modal/Window.js
@@ -26,6 +26,7 @@ export default class Window extends Component {
       body: '',
       footer: '',
     },
+    variant: 'light',
   };
 
   render() {
@@ -40,7 +41,7 @@ export default class Window extends Component {
     } = this.props;
 
     return (
-      <div className={ cx(css[variant], className) } { ...rest }>
+      <div className={ cx(css.root, css[variant], className) } { ...rest }>
         { header && (
           <div className={ cx(css.header, classNames.header) }>
             { header }

--- a/components/Modal/WithActionBar.css
+++ b/components/Modal/WithActionBar.css
@@ -13,9 +13,3 @@
 .body {
   padding-bottom: var(--space-96);
 }
-
-@media(--modal-lg) {
-  .body {
-    padding-bottom: var(--space-144);
-  }
-}

--- a/components/Modal/WithTitleBar.css
+++ b/components/Modal/WithTitleBar.css
@@ -12,9 +12,3 @@
 .body {
   padding-top: var(--space-96);
 }
-
-@media(--modal-lg) {
-  .body {
-    padding-bottom: var(--space-96);
-  }
-}


### PR DESCRIPTION
It seems there is a bug caused by using `webkit-overflow-scrolling: touch;` in tandem with `overflow-y: scroll` and `transform: translate3d()`. This simplifies the `<Modal />` and `<Window />` components so they no longer use a 3d transform and instead only animate their opacity