### PR TITLE
Fix `<CheckboxGroup />` not passing the correct `onChange` fn down

### DIFF
--- a/components/Form/CheckboxGroup/CheckboxGroup.js
+++ b/components/Form/CheckboxGroup/CheckboxGroup.js
@@ -49,7 +49,6 @@ export default class CheckboxGroup extends Component {
     const {
       children,
       Input,
-      onChange,
       optional,
       value,
       name,
@@ -79,7 +78,7 @@ export default class CheckboxGroup extends Component {
             <Input
               id={ id }
               name={ name }
-              onChange={ onChange }
+              onChange={ this.handleChange }
               checked={ checked }
               required={ !optional }
               ref={ setInputRef }


### PR DESCRIPTION
Prior to this change, the rendered `<Checkbox />` would directly run `<CheckboxGroups />`'s `onChange` prop, which results in the checkbox's value being passed up, rather than the accumulated array of checked values. This rectifies that issue