### PR TITLE
Lower modal z-index to give precedent to notifications

### DIFF
--- a/globals/z-index.css
+++ b/globals/z-index.css
@@ -21,7 +21,7 @@
   --z-9: 90;
 
   /* Aliases */
-  --z-modal: var(--z-9);
+  --z-modal: var(--z-8);
   --z-floatingActionBtn: var(--z-6);
   --z-stickyNode: var(--z-5);
   --z-tooltip: var(--z-3);


### PR DESCRIPTION
Our app's notification center currently supplies a z-index of 10 to it's banners. This means *all* elements sit on top of them, causing weird behaviour. Realistically, notifications should sit on top of everything, including modals. This change reduces the modal z-index from the maximum to allow notifications in our app to utilise it instead