### PR TITLE
Add overflow hidden to body class name

### DIFF
--- a/utils/BodyClassNameConductor/BodyClassNameConductor.css
+++ b/utils/BodyClassNameConductor/BodyClassNameConductor.css
@@ -1,3 +1,7 @@
+.overflowHidden {
+  overflow: hidden;
+}
+
 .noScroll {
   overflow: hidden;
   position: fixed;


### PR DESCRIPTION
https://github.com/appearhere/bloom/commit/70bdf8d80b0065eab8d066e1a0ed4251da7d8c82#diff-bf7a952ea594db0c1415b99259c83603R3

This change broke the map on touch devices, position: fixed prevents
gestures on the map