### PR TITLE
Fix `<WithCross />` modal window not being styled correctly

### DIFF
--- a/components/Modal/WithCross.css
+++ b/components/Modal/WithCross.css
@@ -1,6 +1,6 @@
 .dismissContainer {
   float: right;
-  margin-bottom: var(--size-medium);
+  margin-bottom: var(--size-large);
   color: currentColor;
 }
 

--- a/components/Modal/WithCross.js
+++ b/components/Modal/WithCross.js
@@ -32,15 +32,9 @@ class WindowWithCross extends Component {
       ...rest,
     } = this.props;
 
-    const classNames = {
-      header: css.header,
-      body: css.body,
-    };
-
     return (
       <Window
         { ...rest }
-        classNames={ classNames }
         variant={ variant }
       >
         <BtnContainer className={ css.dismissContainer } onClick={ onClose }>


### PR DESCRIPTION
- Enables styling of the underlying `<Window />` component's header,
  body and footer by removing `<WithCross />`'s hard coded classNames
object
- Unifies the margin around the cross within `<WithCross />` with that
  of the padding supplied by `<Window />`