### PR TITLE
Allow `<TabBar />` active marker offset to be turned off

### DIFF
--- a/components/Navigation/TabBar/TabBar.js
+++ b/components/Navigation/TabBar/TabBar.js
@@ -6,7 +6,7 @@ import { Motion, spring } from 'react-motion';
 import { SIBLING_TRANSITION as SPRING_CONFIG } from '../../../constants/springs';
 import css from './TabBar.css';
 
-const TabBar = ({ children, variant, className }) => {
+const TabBar = ({ children, variant, activeMarkerOffset, className }) => {
   const tabWidth = 100 / children.length;
   const activeTabs = children
     .map((child, i) => {
@@ -49,7 +49,7 @@ const TabBar = ({ children, variant, className }) => {
             className={ css.underline }
             style={ {
               width: `${tabWidth}%`,
-              transform: `translate3d(${x}%, -1px,0)`,
+              transform: `translate3d(${x}%, ${activeMarkerOffset}px, 0)`,
             } }
           />
         ) }
@@ -62,10 +62,12 @@ TabBar.propTypes = {
   children: PropTypes.array.isRequired,
   variant: PropTypes.oneOf(['light', 'dark']),
   className: PropTypes.string,
+  activeMarkerOffset: PropTypes.number,
 };
 
 TabBar.defaultProps = {
   variant: 'light',
+  activeMarkerOffset: -1,
 };
 
 export default TabBar;

--- a/components/Navigation/TabBar/TabBar.story.js
+++ b/components/Navigation/TabBar/TabBar.story.js
@@ -10,7 +10,7 @@ stories.addDecorator(withKnobs);
 
 stories
   .add('Default', () => (
-    <TabBar>
+    <TabBar activeMarkerOffset={ number('activeMarkerOffset', -1) }>
       <TabBarItem
         href="#search"
         active={ number('Active tab', 0) === 0 }


### PR DESCRIPTION
`<TabBar />` currently enforces that the active marker is always -1px
away from the bottom of the outer most div. This is to ensure the active
marker sits on top of the `<TabBar />`'s default border. In scenario's
where the parent component wishes to supply its own border, the active
marker should sit on top of the parent's border. This change enables
that by making it possible to turn the offset off via props