### PR TITLE
Add CSS constant for iOS Safari's minimum bottom margin

### DIFF
--- a/globals/constants.css
+++ b/globals/constants.css
@@ -1,0 +1,3 @@
+:root {
+  --ios-safari-bottom-margin: 44px;
+}


### PR DESCRIPTION
44px is the minimum margin from the bottom of the view a button has to
be to prevent the annoying double tap ‘feature’ on Safari iOS