### PR TITLE
Fix children proptype of `Medallion` being too restrictive

### DIFF
--- a/components/Medallion/Medallion.js
+++ b/components/Medallion/Medallion.js
@@ -18,7 +18,7 @@ const Medallion = ({ className, variant, children, ...rest }) => (
 
 Medallion.propTypes = {
   className: PropTypes.string,
-  children: PropTypes.string,
+  children: PropTypes.node,
   variant: PropTypes.oneOf(['light', 'dark']),
 };
 


### PR DESCRIPTION
Medallion currently raises a warning if you pass in a number 