### PR TITLE
Update DayPicker(s) to support more efficient state management

### DIFF
--- a/components/Calendar/CalendarMonth/CalendarMonth.js
+++ b/components/Calendar/CalendarMonth/CalendarMonth.js
@@ -63,9 +63,9 @@ export default class CalendarMonth extends Component {
     const startOfMonth = month.clone().startOf('month');
     const endOfMonth = month.clone().endOf('month');
     const calendarMonth = getCalendarMonth(
-      month,
-      getPreDayCount(month),
-      getPostDayCount(month),
+      startOfMonth,
+      getPreDayCount(startOfMonth),
+      getPostDayCount(startOfMonth),
     );
 
     return (
@@ -73,7 +73,7 @@ export default class CalendarMonth extends Component {
         <thead className={ classNames.head }>
           <tr className={ classNames.row }>
             { head.map((offset) => {
-              const day = moment().clone().day(offset);
+              const day = startOfMonth.clone().weekday(offset);
               return (
                 <td key={ `${month.format('MM')}-${day.format('dd')}` }>
                   <ColumnHeadingComponent

--- a/components/Calendar/DayPicker/DayPicker.js
+++ b/components/Calendar/DayPicker/DayPicker.js
@@ -32,11 +32,7 @@ export default class DayPicker extends Component {
   static propTypes = {
     month: momentPropTypes.momentObj,
     onInteraction: PropTypes.func,
-    onHighlight: PropTypes.func,
     onMonthChange: PropTypes.func,
-    selectedDates: PropTypes.arrayOf(momentPropTypes.momentObj),
-    highlightedDates: PropTypes.arrayOf(momentPropTypes.momentObj),
-    disabledDates: PropTypes.arrayOf(momentPropTypes.momentObj),
     dayProps: PropTypes.object,
     accessibilityNextLabel: PropTypes.string,
     accessibilityPrevLabel: PropTypes.string,
@@ -47,9 +43,6 @@ export default class DayPicker extends Component {
     onInteraction: noop,
     onHighlight: noop,
     onMonthChange: noop,
-    selectedDates: [],
-    highlightedDates: [],
-    disabledDates: [],
     dayProps: {},
     accessibilityNextLabel: 'Go to next month',
     accessibilityPrevLabel: 'Go to previous month',
@@ -70,14 +63,10 @@ export default class DayPicker extends Component {
   render() {
     const {
       month,
-      selectedDates,
-      highlightedDates,
-      disabledDates,
+      dayProps,
+      onInteraction,
       accessibilityNextLabel,
       accessibilityPrevLabel,
-      onInteraction,
-      onHighlight,
-      dayProps,
     } = this.props;
 
     return (
@@ -108,10 +97,6 @@ export default class DayPicker extends Component {
           dayProps={ {
             ...dayProps,
             onInteraction,
-            onHighlight,
-            selectedDates,
-            disabledDates,
-            highlightedDates,
           } }
           DayComponent={ DayPickerItem }
         />

--- a/components/Calendar/DayPicker/DayPicker.story.js
+++ b/components/Calendar/DayPicker/DayPicker.story.js
@@ -2,12 +2,22 @@ import React, { Component } from 'react';
 import { storiesOf } from '@kadira/storybook';
 import { withKnobs, number } from '@kadira/storybook-addon-knobs';
 import moment from 'moment';
-import DayPicker, { getDates } from './DayPicker';
+import DayPicker from './DayPicker';
+import { defaultDayState } from './DayPickerItem';
 
 class StateManagedDayPicker extends Component {
   state = {
     date: '',
     month: moment(),
+  };
+
+  getDayState = (day) => {
+    const { date } = this.state;
+    return Object.assign({}, defaultDayState, {
+      isSelected: day && date && day.isSame(date, 'day'),
+      isFirstSelected: day && date && day.isSame(date, 'day'),
+      isLastSelected: day && date && day.isSame(date, 'day'),
+    });
   };
 
   handleInteraction = (e, date) => {
@@ -19,7 +29,7 @@ class StateManagedDayPicker extends Component {
   };
 
   render() {
-    const { date, month } = this.state;
+    const { month } = this.state;
 
     return (
       <div>
@@ -28,7 +38,9 @@ class StateManagedDayPicker extends Component {
           month={ month }
           onInteraction={ this.handleInteraction }
           onMonthChange={ this.handleMonthChange }
-          selectedDates={ getDates(date) }
+          dayProps={ {
+            getDayState: this.getDayState,
+          } }
         />
       </div>
     );
@@ -43,25 +55,30 @@ const today = moment();
 stories
   .add('Single date selected', () => (
     <DayPicker
-      selectedDates={ getDates(moment()) }
-      month={ moment({ month: number('month', today.month()) }) }
+      dayProps={ {
+        getDayState: d => Object.assign({}, defaultDayState, {
+          isSelected: d && d.isSame(moment(), 'day'),
+          isFirstSelected: d && d.isSame(moment(), 'day'),
+          isLastSelected: d && d.isSame(moment(), 'day'),
+        }),
+      } }
+      month={ moment().month(4) }
     />
   ))
   .add('Multiple dates selected', () => (
     <DayPicker
-      selectedDates={ getDates(moment(), moment().add(5, 'day')) }
-      month={ moment({ month: number('month', today.month()) }) }
-    />
-  ))
-  .add('Single date highlighted', () => (
-    <DayPicker
-      highlightedDates={ getDates(moment()) }
-      month={ moment({ month: number('month', today.month()) }) }
-    />
-  ))
-  .add('Multiple dates highlighted', () => (
-    <DayPicker
-      highlightedDates={ getDates(moment(), moment().add(5, 'day')) }
+      dayProps={ {
+        getDayState: (d) => {
+          const startDate = moment().add(-5, 'day');
+          const endDate = moment().add(5, 'day');
+
+          return Object.assign({}, defaultDayState, {
+            isSelected: d && d.isAfter(startDate, 'day') && d.isBefore(endDate, 'day'),
+            isFirstSelected: d && d.isSame(startDate, 'day'),
+            isLastSelected: d && d.isSame(endDate, 'day'),
+          });
+        },
+      } }
       month={ moment({ month: number('month', today.month()) }) }
     />
   ))

--- a/components/Calendar/DayPicker/DayPickerItem.css
+++ b/components/Calendar/DayPicker/DayPickerItem.css
@@ -18,7 +18,7 @@
 
 .disabled {
   pointer-events: none;
-  color: var(--color-grey);
+  color: var(--color-greyLight);
 }
 
 .firstSelected.lastSelected {

--- a/components/Calendar/DayPicker/DayPickerItem.test.js
+++ b/components/Calendar/DayPicker/DayPickerItem.test.js
@@ -106,7 +106,9 @@ describe('DayPickerItem', () => {
           ref={ (c) => { component = c; } }
           day={ now }
           onInteraction={ spy }
-          disabledDates={ [now] }
+          getDayState={ () => ({
+            isDisabled: true,
+          }) }
         />,
         div
       );
@@ -168,7 +170,9 @@ describe('DayPickerItem', () => {
           ref={ (c) => { component = c; } }
           day={ now }
           onHighlight={ spy }
-          disabledDates={ [now] }
+          getDayState={ () => ({
+            isDisabled: true,
+          }) }
         />,
         div
       );

--- a/components/Calendar/DayRangePicker/DayRangePicker.test.js
+++ b/components/Calendar/DayRangePicker/DayRangePicker.test.js
@@ -2,7 +2,7 @@
 import React from 'react';
 import { render } from 'react-dom';
 
-import DayRangePicker, { SELECT_DATE } from './DayRangePicker';
+import DayRangePicker, { SELECT_DATE, dayInRange } from './DayRangePicker';
 import moment from '../../../utils/moment/moment';
 
 describe('DayRangePicker', () => {
@@ -205,5 +205,30 @@ describe('DayRangePicker', () => {
       expect(spy.calls.mostRecent().args[1].isSame(selected)).toBe(true);
       expect(spy.calls.mostRecent().args[2]).toBe(null);
     });
+  });
+});
+
+describe('dayInRange', () => {
+  it('returns false when not given a day', () => {
+    expect(dayInRange()).toBe(false);
+  });
+
+  it('returns true when the date the same as the start date', () => {
+    const today = moment();
+    const startDate = moment();
+    expect(dayInRange(today, startDate, undefined)).toBe(true);
+  });
+
+  it('returns true when the date the same as the end date', () => {
+    const today = moment();
+    const endDate = moment();
+    expect(dayInRange(today, undefined, endDate)).toBe(true);
+  });
+
+  it('returns true when the date between the start and end date', () => {
+    const today = moment();
+    const startDate = moment().add(-1, 'day');
+    const endDate = moment().add(1, 'day');
+    expect(dayInRange(today, startDate, endDate)).toBe(true);
   });
 });

--- a/components/Calendar/getCalendarMonth/getCalendarMonth.js
+++ b/components/Calendar/getCalendarMonth/getCalendarMonth.js
@@ -9,7 +9,7 @@ export const DAYS_PER_WEEK = 7;
 export const CALENDAR_ROWS = CALENDAR_MONTH_LENGTH / DAYS_PER_WEEK;
 
 export const getPreDayCount = (date) => {
-  const weekday = date.weekday();
+  const weekday = date.clone().startOf('month').weekday();
   return weekday > 0 ? weekday - 1 : 0;
 };
 


### PR DESCRIPTION
Instead of multiple arrays of dates, pass in a function which returns
the state of any given day, allowing for more complex and efficient
state management. This enables the possibility to blanket disabled dates
before a certain date without the overhead of generating an array of the
disabled dates