### PR TITLE
Fix CSS ordering of day picker

### DIFF
--- a/components/Calendar/DayPicker/DayPicker.js
+++ b/components/Calendar/DayPicker/DayPicker.js
@@ -3,7 +3,6 @@ import cx from 'classnames';
 import momentPropTypes from 'react-moment-proptypes';
 import keyMirror from 'key-mirror';
 
-import css from './DayPicker.css';
 import Icon from '../../Icon/Icon';
 import noop from '../../../utils/noop';
 import DayPickerItem from './DayPickerItem';
@@ -11,6 +10,7 @@ import moment from '../../../utils/moment/moment';
 import BtnContainer from '../../BtnContainer/BtnContainer';
 import ScreenReadable from '../../ScreenReadable/ScreenReadable';
 import CalendarMonth, { defaultClassNames } from '../CalendarMonth/CalendarMonth';
+import css from './DayPicker.css';
 
 const classNames = Object.assign({}, defaultClassNames, {
   head: cx(defaultClassNames.head, css.head),


### PR DESCRIPTION
By importing the day picker's css file _after_ the `<CalendarMonth />`
we ensure that the webpack generated css file orders the CSS correctly,
i.e., placing calendar month styles before day picker styles. This
allows the day picker to override the calendar month styles