### PR TITLE
Fix the map moving unnecessary when receiving new props

### DIFF
--- a/components/Map/BaseMap.js
+++ b/components/Map/BaseMap.js
@@ -69,7 +69,8 @@ export default class BaseMap extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    const { center, zoom } = this.props;
+    const center = this.map.getCenter().toArray();
+    const zoom = this.map.getZoom();
     const { center: nextCenter, zoom: nextZoom } = nextProps;
 
     if (center[0] !== nextCenter[0] || center[1] !== nextCenter[1]) this.map.setCenter(nextCenter);

--- a/utils/mapboxgl/__mocks__/mapboxgl.js
+++ b/utils/mapboxgl/__mocks__/mapboxgl.js
@@ -21,6 +21,12 @@ class Map {
     mapSpy('getZoom');
     return 10;
   }
+  getCenter = () => {
+    mapSpy('getCenter');
+    return {
+      toArray: () => [],
+    };
+  }
 }
 
 class Marker {


### PR DESCRIPTION
onMoveEnd was unnecessarily being called multiple times. Getting the current centre and zoom from the map instead of current props prevents this.