### PR TITLE
Fix `<PlaceListingCard />`'s focus styles

### DIFF
--- a/components/Cards/PictureCard/PictureCard.css
+++ b/components/Cards/PictureCard/PictureCard.css
@@ -28,7 +28,8 @@
   left: 0;
 }
 
-.link:hover .overlay {
+.link:hover .overlay,
+.link:focus .overlay {
   opacity: 0.6;
 }
 

--- a/components/Cards/PlaceListingCard/PlaceListingCard.css
+++ b/components/Cards/PlaceListingCard/PlaceListingCard.css
@@ -5,7 +5,8 @@
   border-radius: var(--size-sm-iii);
 }
 
-.root:hover {
+.root:hover,
+.root:focus {
   color: var(--color-white);
 }
 


### PR DESCRIPTION
- Focusing on the cards now has the same effect as hovering over them
- Focus styles are more resiliant to side-effects caused by other
  libraries