### PR TITLE
Fix space group cards not opening on the markable map

### DIFF
--- a/components/Map/MarkableMap.js
+++ b/components/Map/MarkableMap.js
@@ -102,6 +102,11 @@ export default class MarkableMap extends Component {
     const { markers } = this.props;
     const { activeFeature } = this.state;
 
+    if (activeFeature.properties.cluster) {
+      const markerIds = JSON.parse(activeFeature.properties.markerids);
+      return find(marker => markerIds.indexOf(marker.id) > -1, markers);
+    }
+
     if (activeFeature) {
       return find({ id: activeFeature.properties.id }, markers);
     }


### PR DESCRIPTION
As part of the work to make popups close if the marker no longer exists
in the map (#272), clusters on the map no longer opened their space
group marker when applicable. This rectifies this issue by ensuring
`getActiveFeaturedMarker` will look to match *any* present marker if the
active feature is a cluster