### PR TITLE
Add `<Roll />` animation component

### DIFF
--- a/components/Animate/Animate.story.js
+++ b/components/Animate/Animate.story.js
@@ -1,5 +1,7 @@
 import React, { Component } from 'react';
+import keyMirror from 'key-mirror';
 import { storiesOf, linkTo } from '@kadira/storybook';
+import { withKnobs, select } from '@kadira/storybook-addon-knobs';
 
 import Circle from './Circle';
 import Sunrise from './Sunrise';
@@ -8,6 +10,8 @@ import GraphOrnament from './GraphOrnament';
 import EdgeFade from './EdgeFade';
 import SplitWordEntrance from './SplitWordEntrance';
 import Typewriter from './Typewriter';
+import Roll from './Roll';
+import Btn from '../Btn/Btn';
 import m from '../../globals/modifiers.css';
 
 const sunrisePanels = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20];
@@ -48,80 +52,102 @@ class TestSunriseComponent extends Component {
 }
 
 
-storiesOf('Animation', module)
-  .add('Sunrise', () => (
-    <div>
-      { sunrisePanels.map(() => (
-        <Sunrise percent={ 50 }>
-          <div
-            className={ m.bgPrimary }
-            style={ {
-              width: '300px',
-              height: '400px',
-              marginRight: '2%',
-              marginTop: '2rem',
-            } }
-          />
-        </Sunrise>
-      )) }
-    </div>
-  ))
-  .add('Sunrise with start', () => (
-    <TestSunriseComponent />
-  ))
-  .add('Swap', () => (
-    <div>
-      <p>
-        See <code>&lt;Swap /&gt;</code> in action in the <code>&lt;GridFader /&gt;</code> component
-      </p>
-      <button onClick={ linkTo('GridFader', 'First') }>Go to GridFader</button>
-    </div>
-  ))
-  .add('<Counter />', () => (
-    <Counter
-      className={ m.fontRegular }
-      transform={ val => val.toFixed(0) }
-      startValue={ 0 }
-      endValue={ 33000000 }
-    />
-  ))
-  .add('<Counter />: Naive currency', () => (
-    <Counter
-      className={ m.fontRegular }
-      transform={ val => `£${val.toFixed(0)}` }
-      startValue={ 0 }
-      endValue={ 33000000 }
-    />
-  ))
-  .add('<Circle />', () => (
-    <div style={ { maxWidth: '100px' } }>
-      <Circle percent={ 50 } />
-      <Circle percent={ 75 } />
-      <Circle percent={ 25 } />
-      <Circle percent={ 100 } />
-    </div>
-  ))
-  .add('<GraphOrnament />', () => (
-    <div style={ { maxWidth: '500px' } }>
-      <GraphOrnament animate play />
-    </div>
-  ))
-  .add('<EdgeFade />', () => (
-    <div>
-      <div style={ { height: '100vh' } } />
-      <EdgeFade>
-        Text that’ll fade in an out when it reaches a certain distance from the top or bottom edge
-      </EdgeFade>
-      <div style={ { height: '100vh' } } />
-    </div>
-  ))
-  .add('<SplitWordEntrance />', () => (
-    <SplitWordEntrance className={ m.fontLgIii }>
-      Introducing Landlord Dashboards
-    </SplitWordEntrance>
-  ))
-  .add('<Typewriter />', () => (
-    <Typewriter className={ m.fontLgIii }>
-      Introducing Landlord Dashboards
-    </Typewriter>
-  ));
+const stories = storiesOf('Animate', module);
+stories.addDecorator(withKnobs);
+
+const labels = [
+  'Map',
+  'Results',
+];
+
+stories.add('Sunrise', () => (
+  <div>
+    { sunrisePanels.map(() => (
+      <Sunrise percent={ 50 }>
+        <div
+          className={ m.bgPrimary }
+          style={ {
+            width: '300px',
+            height: '400px',
+            marginRight: '2%',
+            marginTop: '2rem',
+          } }
+        />
+      </Sunrise>
+    )) }
+  </div>
+))
+.add('Sunrise with start', () => (
+  <TestSunriseComponent />
+))
+.add('Swap', () => (
+  <div>
+    <p>
+      See <code>&lt;Swap /&gt;</code> in action in the <code>&lt;GridFader /&gt;</code> component
+    </p>
+    <button onClick={ linkTo('GridFader', 'First') }>Go to GridFader</button>
+  </div>
+))
+.add('<Counter />', () => (
+  <Counter
+    className={ m.fontRegular }
+    transform={ val => val.toFixed(0) }
+    startValue={ 0 }
+    endValue={ 33000000 }
+  />
+))
+.add('<Counter />: Naive currency', () => (
+  <Counter
+    className={ m.fontRegular }
+    transform={ val => `£${val.toFixed(0)}` }
+    startValue={ 0 }
+    endValue={ 33000000 }
+  />
+))
+.add('<Circle />', () => (
+  <div style={ { maxWidth: '100px' } }>
+    <Circle percent={ 50 } />
+    <Circle percent={ 75 } />
+    <Circle percent={ 25 } />
+    <Circle percent={ 100 } />
+  </div>
+))
+.add('<GraphOrnament />', () => (
+  <div style={ { maxWidth: '500px' } }>
+    <GraphOrnament animate play />
+  </div>
+))
+.add('<EdgeFade />', () => (
+  <div>
+    <div style={ { height: '100vh' } } />
+    <EdgeFade>
+      Text that’ll fade in an out when it reaches a certain distance from the top or bottom edge
+    </EdgeFade>
+    <div style={ { height: '100vh' } } />
+  </div>
+))
+.add('<SplitWordEntrance />', () => (
+  <SplitWordEntrance className={ m.fontLgIii }>
+    Introducing Landlord Dashboards
+  </SplitWordEntrance>
+))
+.add('<Typewriter />', () => (
+  <Typewriter className={ m.fontLgIii }>
+    Introducing Landlord Dashboards
+  </Typewriter>
+))
+.add('<Roll />', () => {
+  const opts = keyMirror({
+    [labels[0]]: null,
+    [labels[1]]: null,
+  });
+  const value = select('Label', opts, labels[0]);
+
+  return (
+    <Btn>
+      <Roll width="12rem">
+        <span id={ value } key={ value }>{ value }</span>
+      </Roll>
+    </Btn>
+  );
+});

--- a/components/Animate/Roll.js
+++ b/components/Animate/Roll.js
@@ -1,0 +1,69 @@
+import React, { Component, PropTypes } from 'react';
+import { spring, TransitionMotion } from 'react-motion';
+
+export default class Roll extends Component {
+  static propTypes = {
+    children: PropTypes.any,
+    width: PropTypes.string,
+  };
+
+  static defaultProps = {
+    width: 'auto',
+  };
+
+  getStyles = () => ({
+    y: spring(0),
+    opacity: spring(1),
+  });
+
+  willEnter = () => ({
+    y: 100,
+    opacity: 0,
+  });
+
+  willLeave = () => ({
+    y: spring(-100),
+    opacity: spring(0),
+  });
+
+  render() {
+    const { children: child, width } = this.props;
+
+    return (
+      <TransitionMotion
+        styles={ [{
+          key: child.props.id,
+          style: this.getStyles(),
+          data: child,
+        }] }
+        willEnter={ this.willEnter }
+        willLeave={ this.willLeave }
+      >
+        { interpolated => (
+          <div
+            style={ {
+              position: 'relative',
+              display: 'inline-block',
+              verticalAlign: 'top',
+              width,
+            } }
+          >
+            { interpolated.map(({ key, data, style }) => (
+              <div
+                key={ key }
+                style={ {
+                  position: style.y === 0 ? 'relative' : 'absolute',
+                  opacity: style.opacity,
+                  transform: `translate3d(0, ${style.y}%, 0)`,
+                  width,
+                } }
+              >
+                { data }
+              </div>
+            )) }
+          </div>
+        )}
+      </TransitionMotion>
+    );
+  }
+}

--- a/components/Animate/Roll.test.js
+++ b/components/Animate/Roll.test.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import { render } from 'react-dom';
+import Roll from './Roll';
+
+it('renders without crashing', () => {
+  const div = document.createElement('div');
+  render(
+    <Roll><span id="lol" /></Roll>,
+    div
+  );
+});


### PR DESCRIPTION
Add a roll animation component, useful for highlighting when smaller parts of the UI change based on a change in state, e.g.:

![gottasupplyawidth](https://cloud.githubusercontent.com/assets/2162181/26690022/b7c1be9e-46ef-11e7-925b-d8c8d4e32b2f.gif)

One caveat is the requirement to supply a width if the animation is to take place inside an element which automatically sizes it's width. If no width is supplied, the element will collapse on itself and look rubbish 😕 