### PR TITLE
Default `<BtnContainer />` to type "button"

### DIFF
--- a/components/BtnContainer/BtnContainer.js
+++ b/components/BtnContainer/BtnContainer.js
@@ -23,4 +23,8 @@ BtnContainer.propTypes = {
   type: PropTypes.oneOf(['submit', 'button', 'reset', 'menu']),
 };
 
+BtnContainer.defaultProps = {
+  type: 'button',
+};
+
 export default BtnContainer;


### PR DESCRIPTION
Ensures the `<BtnContainer />` component doesn't submit form's by
default and instead works as a passive button