### PR TITLE
Adds height to carousel image container

### DIFF
--- a/components/Cards/DestinationListingCard/DestinationListingCard.css
+++ b/components/Cards/DestinationListingCard/DestinationListingCard.css
@@ -95,6 +95,11 @@
   overflow: hidden;
 }
 
+.fixedHeight .imageContainer {
+  height: var(--destination-listing-image-height);
+  padding-bottom: 0;
+}
+
 .image {
   position: absolute;
   top: 0;

--- a/components/Cards/DestinationListingCard/DestinationListingCard.js
+++ b/components/Cards/DestinationListingCard/DestinationListingCard.js
@@ -30,6 +30,7 @@ export default class DestinationListingCard extends Component {
     carouselOverlay: PropTypes.node,
     information: PropTypes.array,
     onClick: PropTypes.func,
+    fixedHeight: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -38,6 +39,7 @@ export default class DestinationListingCard extends Component {
     href: '#',
     images: [],
     information: [],
+    fixedHeight: false,
   };
 
   state = {
@@ -81,11 +83,19 @@ export default class DestinationListingCard extends Component {
       carouselOverlay,
       information,
       onClick,
+      fixedHeight,
       ...rest,
     } = this.props;
 
     return (
-      <div { ...rest } className={ cx(css.root, className) }>
+      <div
+        { ...rest }
+        className={ cx(
+          css.root,
+          className,
+          fixedHeight ? css.fixedHeight : null
+        ) }
+      >
         <div className={ cx(css.carousel, carouselClassName) }>
           { carouselOverlay }
           <BtnContainer

--- a/globals/constants.css
+++ b/globals/constants.css
@@ -1,4 +1,5 @@
 :root {
   --ios-safari-bottom-margin: 44px;
   --destination-listing-content-height: 7.375rem;
+  --destination-listing-image-height: 8.4375rem;
 }


### PR DESCRIPTION
## Description

The following commit broke the initial load of map carousel images as it removes the height (specified as `var(--destination-listing-image-height)`) of the image (imageContainer) https://github.com/appearhere/bloom/commit/3faaa8de2cbc0feb7f514df9322f6f9004d67c43
. Without a specified height, the initial image load height is set to 0px.

This reintroduces the height attribute if a fixedHeight flag is passed through.

## Questions

Should I be reintroduce the global variable `--destination-listing-image-height` for this as before?