### PR TITLE
Moves place link above carousel button

### DIFF
--- a/components/Cards/SpaceListingCard/SpaceListingCard.css
+++ b/components/Cards/SpaceListingCard/SpaceListingCard.css
@@ -9,7 +9,7 @@
   position: absolute;
   top: var(--size-small);
   right: var(--size-small);
-  z-index: 1;
+  z-index: 2;
   line-height: 1;
   transition: background-color 100ms;
   max-width: 80%;


### PR DESCRIPTION
Increases Z-index of place link on space cards so when the far right of the place link is clicked, it responds (instead of carousel next picture button)

![image](https://user-images.githubusercontent.com/4599695/27700758-7de21cf6-5cf6-11e7-80da-e2b9230336b8.png)
