### PR TITLE
Fix pagination link active `:focus` styles

### DIFF
--- a/components/Pagination/PaginationLink.css
+++ b/components/Pagination/PaginationLink.css
@@ -37,14 +37,17 @@
 }
 
 .active,
-.active:hover {
+.active:hover,
+.active:focus {
   color: var(--color-white);
   background-color: var(--color-grey);
   border: 1px solid var(--color-grey);
 }
 
-.active:hover {
+.active:hover,
+.active:focus {
   background-color: var(--color-grey);
+  color: var(--color-white);
 }
 
 .nextArrow,


### PR DESCRIPTION
- Ensures `.active:focus` styles are more robust, preventing other libraries from leaking their styling onto the links
- Ensures the `.active:focus` border colour is the correct one