### PR TITLE
Fix `<ControlLayer />` not accepting multiple children

### DIFF
--- a/components/Map/ControlLayer/ControlLayer.js
+++ b/components/Map/ControlLayer/ControlLayer.js
@@ -34,7 +34,7 @@ const ControlLayer = (props) => {
 ControlLayer.propTypes = {
   className: PropTypes.string,
   controlGroupClassName: PropTypes.string,
-  children: PropTypes.element.isRequired,
+  children: PropTypes.node.isRequired,
   onZoomIn: PropTypes.func.isRequired,
   onZoomOut: PropTypes.func.isRequired,
 };


### PR DESCRIPTION
Control layer previously assumed its only child would be a map. In practise it should be able to accept the map *and* additional controls