### PR TITLE
Add low priority option to input component

### DIFF
--- a/components/Form/AutoComplete/Input.css
+++ b/components/Form/AutoComplete/Input.css
@@ -9,7 +9,6 @@
 
 input.input[type="text"] {
   outline: 0;
-  padding: var(--size-regular) var(--size-lg-i);
 }
 
 .activeMarker {

--- a/components/Form/Input/Input.css
+++ b/components/Form/Input/Input.css
@@ -52,6 +52,15 @@ textarea.high {
   padding: var(--size-regular) var(--size-lg-i);
 }
 
+input.low[type='text'],
+input.low[type='email'],
+input.low[type='password'],
+input.low[type='search'],
+input.low[type='url'],
+textarea.low {
+  padding: var(--size-sm-ii) var(--size-sm-i);
+}
+
 textarea.input {
   min-height: 5rem;
 }

--- a/components/Form/Input/Input.js
+++ b/components/Form/Input/Input.js
@@ -43,7 +43,7 @@ export default class Input extends Component {
       'url',
       'textarea',
     ]),
-    priority: PropTypes.oneOf(['high']),
+    priority: PropTypes.oneOf(['high', 'low']),
   };
 
   static defaultProps = {

--- a/components/Form/Input/Input.story.js
+++ b/components/Form/Input/Input.story.js
@@ -37,4 +37,16 @@ stories.add('Input', () => (
     error={ boolean('Errored', false) ? 'Something went wrong' : '' }
     priority="high"
   />
+))
+.add('Input w/low priority', () => (
+  <Input
+    id="1"
+    type={ select('Type', inputTypes, inputTypes[0]) }
+    value="100"
+    onFocus={ action('Focus') }
+    onBlur={ action('Blur') }
+    onChange={ action('Change') }
+    error={ boolean('Errored', false) ? 'Something went wrong' : '' }
+    priority="low"
+  />
 ));


### PR DESCRIPTION
Adds a low priority option to `<Input />`, for scenarios where the inputs are secondary to other parts of the interface they are apart of