### PR TITLE
Add H3 titles to button documentation

### DIFF
--- a/styleguide/screens/Patterns/Buttons/Buttons.css
+++ b/styleguide/screens/Patterns/Buttons/Buttons.css
@@ -11,3 +11,8 @@
   vertical-align: middle;
   display: inline-block;
 }
+
+.componentTitle {
+	padding-top: var(--size-lg-ii);
+	border-top: 1px solid var(--color-greyLighter);
+}

--- a/styleguide/screens/Patterns/Buttons/Buttons.css
+++ b/styleguide/screens/Patterns/Buttons/Buttons.css
@@ -11,8 +11,3 @@
   vertical-align: middle;
   display: inline-block;
 }
-
-.componentTitle {
-	padding-top: var(--size-lg-ii);
-	border-top: 1px solid var(--color-greyLighter);
-}

--- a/styleguide/screens/Patterns/Buttons/Buttons.js
+++ b/styleguide/screens/Patterns/Buttons/Buttons.js
@@ -22,7 +22,6 @@ const Buttons = () => (
     </T>
     <D>
       <H level={ 2 }>Btn</H>
-      <H level={ 3 } className={ m.mtLgIi }>Standard Buttons</H>
       <T elm="p" className={ m.mtr }>
         This is your standard button. They typically trigger one action when
         interacted with, providing the basis for creating an interactive page.
@@ -48,7 +47,7 @@ const Buttons = () => (
         <Btn context="danger" className={ css.btn }>Danger</Btn>
         <Btn context="whiteout" className={ css.btn }>Whiteout</Btn>
       </Specimen>
-      <H level={ 3 } className={ m.mtLgIi }>Hollow Buttons</H>
+      <H level={ 3 } className={ m.mtLgIi }>Hollow</H>
       <T elm="p" className={ m.mtr }>
         These are our hollow buttons. Use them for secondary actions.
         Most of the time, this will be when used alongside a standard
@@ -74,7 +73,7 @@ const Buttons = () => (
         <Btn variant="hollow" context="danger" className={ css.btn }>Danger</Btn>
         <Btn variant="hollow" context="whiteout" className={ css.btn }>Whiteout</Btn>
       </Specimen>
-      <H level={ 3 } className={ m.mtLgIi }>Subtle Buttons</H>
+      <H level={ 3 } className={ m.mtLgIi }>Subtle</H>
       <T elm="p" className={ m.mtr }>
         These are our subtle buttons. Use them for when the action is not
         overly important and should blend into its surroundings.
@@ -99,7 +98,7 @@ const Buttons = () => (
         <Btn variant="subtle" context="danger" className={ css.btn }>Danger</Btn>
         <Btn variant="subtle" context="whiteout" className={ css.btn }>Whiteout</Btn>
       </Specimen>
-      <H level={ 3 } className={ m.mtLgIi }>Icon button</H>
+      <H level={ 3 } className={ m.mtLgIi }>Icon</H>
       <T elm="p" className={ m.mtr }>
         Adding an icon is as simple as using the icon component within the
         button’s label. Icons should always placed on the left, and have a
@@ -120,7 +119,7 @@ const Buttons = () => (
           Default
         </Btn>
       </Specimen>
-      <H level={ 3 } className={ m.mtLgIi }>Loading button</H>
+      <H level={ 3 } className={ m.mtLgIi }>Loading</H>
       <T elm="p" className={ m.mtr }>
         When adding a loader, apply the same rules as a regular icon.
       </T>
@@ -139,7 +138,7 @@ const Buttons = () => (
           Default
         </Btn>
       </Specimen>
-      <H level={ 3 } className={ m.mtLgIi }>Medalion button</H>
+      <H level={ 3 } className={ m.mtLgIi }>Medalion</H>
       <T elm="p" className={ m.mtr }>
         Similarly to icons and loaders, medallions can also be added to buttons.
         These must be placed on the right hand side of the label, and have a
@@ -160,7 +159,7 @@ const Buttons = () => (
           <Medallion className={ m.mlr }>1</Medallion>
         </Btn>
       </Specimen>
-      <H level={ 3 } className={ m.mtLgIi }>Wide button</H>
+      <H level={ 3 } className={ m.mtLgIi }>Wide</H>
       <T elm="p" className={ m.mtr }>
         When using one button, there are times you may want it to be full width.
         Use the className prop to achieve this.
@@ -177,7 +176,7 @@ const Buttons = () => (
       >
         <Btn className={ m.widthFull }>Default</Btn>
       </Specimen>
-      <H level={ 3 } className={ m.mtLgIi }>Disabled Button</H>
+      <H level={ 3 } className={ m.mtLgIi }>Disabled</H>
       <T elm="p" className={ m.mtr }>
         Disable the button like you would any supported HTML element.
       </T>
@@ -188,18 +187,18 @@ const Buttons = () => (
         } }
         attributes={ [
           'Disabled',
-          '<Btn disabled>Disabled</Btn>',
+          '<Btn disabled>Default</Btn>',
           '<Btn disabled variant="hollow" context="primary">Primary</Btn>',
           '<Btn disabled variant="subtle" context="action">Action</Btn>',
         ] }
       >
-        <Btn disabled className={ css.btn }>Disabled</Btn>
+        <Btn disabled className={ css.btn }>Default</Btn>
         <Btn disabled variant="hollow" context="primary" className={ css.btn }>Primary</Btn>
         <Btn disabled variant="subtle" context="action" className={ css.btn }>Action</Btn>
       </Specimen>
     </D>
     <D>
-      <H level={ 2 }>BtnGroup</H>
+      <H level={ 2 } className={ css.componentTitle }>BtnGroup</H>
       <T elm="p" className={ m.mtr }>
         Use button groups when adding a set of actions with a common theme to
         a page. They are only designed to work with buttons with no variant
@@ -237,7 +236,7 @@ const Buttons = () => (
       </Specimen>
     </D>
     <D>
-      <H level={ 2 }>BtnContainer</H>
+      <H level={ 2 } className={ css.componentTitle }>BtnContainer</H>
       <T elm="p" className={ m.mtr }>
         The button container is for the moments when you really want to use a div.
         Use it as a way of correctly marking up parts of the application that

--- a/styleguide/screens/Patterns/Buttons/Buttons.js
+++ b/styleguide/screens/Patterns/Buttons/Buttons.js
@@ -22,6 +22,7 @@ const Buttons = () => (
     </T>
     <D>
       <H level={ 2 }>Btn</H>
+      <H level={ 3 } className={ m.mtLgIi }>Standard Buttons</H>
       <T elm="p" className={ m.mtr }>
         This is your standard button. They typically trigger one action when
         interacted with, providing the basis for creating an interactive page.
@@ -47,6 +48,7 @@ const Buttons = () => (
         <Btn context="danger" className={ css.btn }>Danger</Btn>
         <Btn context="whiteout" className={ css.btn }>Whiteout</Btn>
       </Specimen>
+      <H level={ 3 } className={ m.mtLgIi }>Hollow Buttons</H>
       <T elm="p" className={ m.mtr }>
         These are our hollow buttons. Use them for secondary actions.
         Most of the time, this will be when used alongside a standard
@@ -72,6 +74,7 @@ const Buttons = () => (
         <Btn variant="hollow" context="danger" className={ css.btn }>Danger</Btn>
         <Btn variant="hollow" context="whiteout" className={ css.btn }>Whiteout</Btn>
       </Specimen>
+      <H level={ 3 } className={ m.mtLgIi }>Subtle Buttons</H>
       <T elm="p" className={ m.mtr }>
         These are our subtle buttons. Use them for when the action is not
         overly important and should blend into its surroundings.
@@ -96,6 +99,7 @@ const Buttons = () => (
         <Btn variant="subtle" context="danger" className={ css.btn }>Danger</Btn>
         <Btn variant="subtle" context="whiteout" className={ css.btn }>Whiteout</Btn>
       </Specimen>
+      <H level={ 3 } className={ m.mtLgIi }>Icon button</H>
       <T elm="p" className={ m.mtr }>
         Adding an icon is as simple as using the icon component within the
         button’s label. Icons should always placed on the left, and have a
@@ -116,6 +120,7 @@ const Buttons = () => (
           Default
         </Btn>
       </Specimen>
+      <H level={ 3 } className={ m.mtLgIi }>Loading button</H>
       <T elm="p" className={ m.mtr }>
         When adding a loader, apply the same rules as a regular icon.
       </T>
@@ -134,6 +139,7 @@ const Buttons = () => (
           Default
         </Btn>
       </Specimen>
+      <H level={ 3 } className={ m.mtLgIi }>Medalion button</H>
       <T elm="p" className={ m.mtr }>
         Similarly to icons and loaders, medallions can also be added to buttons.
         These must be placed on the right hand side of the label, and have a
@@ -154,6 +160,7 @@ const Buttons = () => (
           <Medallion className={ m.mlr }>1</Medallion>
         </Btn>
       </Specimen>
+      <H level={ 3 } className={ m.mtLgIi }>Wide button</H>
       <T elm="p" className={ m.mtr }>
         When using one button, there are times you may want it to be full width.
         Use the className prop to achieve this.
@@ -170,6 +177,7 @@ const Buttons = () => (
       >
         <Btn className={ m.widthFull }>Default</Btn>
       </Specimen>
+      <H level={ 3 } className={ m.mtLgIi }>Disabled Button</H>
       <T elm="p" className={ m.mtr }>
         Disable the button like you would any supported HTML element.
       </T>

--- a/styleguide/screens/Patterns/Buttons/Buttons.js
+++ b/styleguide/screens/Patterns/Buttons/Buttons.js
@@ -11,6 +11,7 @@ import Medallion from '../../../../components/Medallion/Medallion';
 import Specimen from '../../../components/Specimen/Specimen';
 import { H, T, C, D } from '../../../components/Scaffold/Scaffold';
 import css from './Buttons.css';
+import shared from '../../../../styleguide/shared.css';
 import m from '../../../../globals/modifiers.css';
 
 const Buttons = () => (
@@ -138,7 +139,7 @@ const Buttons = () => (
           Default
         </Btn>
       </Specimen>
-      <H level={ 3 } className={ m.mtLgIi }>Medalion</H>
+      <H level={ 3 } className={ m.mtLgIi }>Medallion</H>
       <T elm="p" className={ m.mtr }>
         Similarly to icons and loaders, medallions can also be added to buttons.
         These must be placed on the right hand side of the label, and have a
@@ -159,7 +160,7 @@ const Buttons = () => (
           <Medallion className={ m.mlr }>1</Medallion>
         </Btn>
       </Specimen>
-      <H level={ 3 } className={ m.mtLgIi }>Wide</H>
+      <H level={ 3 } className={ m.mtLgIi }>Full width</H>
       <T elm="p" className={ m.mtr }>
         When using one button, there are times you may want it to be full width.
         Use the className prop to achieve this.
@@ -198,7 +199,7 @@ const Buttons = () => (
       </Specimen>
     </D>
     <D>
-      <H level={ 2 } className={ css.componentTitle }>BtnGroup</H>
+      <H level={ 2 } className={ shared.componentTitle }>BtnGroup</H>
       <T elm="p" className={ m.mtr }>
         Use button groups when adding a set of actions with a common theme to
         a page. They are only designed to work with buttons with no variant
@@ -236,7 +237,7 @@ const Buttons = () => (
       </Specimen>
     </D>
     <D>
-      <H level={ 2 } className={ css.componentTitle }>BtnContainer</H>
+      <H level={ 2 } className={ shared.componentTitle }>BtnContainer</H>
       <T elm="p" className={ m.mtr }>
         The button container is for the moments when you really want to use a div.
         Use it as a way of correctly marking up parts of the application that

--- a/styleguide/shared.css
+++ b/styleguide/shared.css
@@ -1,0 +1,4 @@
+.componentTitle {
+  padding-top: var(--size-lg-ii);
+  border-top: 1px solid var(--color-greyLighter);
+}


### PR DESCRIPTION
- Suggest we break content up to make it more readable, and easier to digest.
- Also increased spacing between each component