### PR TITLE
Add scroll reset on router transition

### DIFF
--- a/styleguide/Styleguide.js
+++ b/styleguide/Styleguide.js
@@ -9,6 +9,7 @@ import Icon from '../components/Icon/Icon';
 import ScreenReadable from '../components/ScreenReadable/ScreenReadable';
 import Wrapper from '../components/Wrapper/Wrapper';
 import BodyClassNameConductor from '../utils/BodyClassNameConductor/BodyClassNameConductor';
+import ScrollToTop from './components/ScrollToTop/ScrollToTop';
 
 /* Pages */
 import Introduction from './screens/Overview/Introduction';
@@ -53,45 +54,47 @@ export default class Styleguide extends Component {
 
     return (
       <BrowserRouter>
-        <div className={ css.root }>
-          <BtnContainer className={ css.menuBtn } onClick={ this.openNavigation }>
-            <Icon className={ css.menuIcon } name="menu" />
-            <ScreenReadable>Open menu</ScreenReadable>
-          </BtnContainer>
-          <OffCanvasPanel
-            className={ css.navigationSm }
-            activeClassName={ css.navigationActive }
-            active={ showNavigation }
-            onClose={ this.closeNavigation }
-          >
-            <SiteHeader
-              version={ process.env.npm_package_version }
-              onLinkClick={ this.closeMenu }
-            />
-            <Navigation onLinkClick={ this.closeNavigation } />
-          </OffCanvasPanel>
-          <div className={ css.navigationLg }>
-            <SiteHeader
-              version={ process.env.npm_package_version }
-              onLinkClick={ this.closeMenu }
-            />
-            <Navigation onLinkClick={ this.closeNavigation } />
-          </div>
-          <div className={ css.body }>
-            <Wrapper className={ css.wrapper }>
-              <Switch>
-                <Route exact path="/" component={ Introduction } />
-                <Route path="/design/colors" component={ Colors } />
-                <Route path="/design/typography" component={ Typography } />
-                <Route path="/design/iconography" component={ Iconography } />
+        <ScrollToTop>
+          <div className={ css.root }>
+            <BtnContainer className={ css.menuBtn } onClick={ this.openNavigation }>
+              <Icon className={ css.menuIcon } name="menu" />
+              <ScreenReadable>Open menu</ScreenReadable>
+            </BtnContainer>
+            <OffCanvasPanel
+              className={ css.navigationSm }
+              activeClassName={ css.navigationActive }
+              active={ showNavigation }
+              onClose={ this.closeNavigation }
+            >
+              <SiteHeader
+                version={ process.env.npm_package_version }
+                onLinkClick={ this.closeMenu }
+              />
+              <Navigation onLinkClick={ this.closeNavigation } />
+            </OffCanvasPanel>
+            <div className={ css.navigationLg }>
+              <SiteHeader
+                version={ process.env.npm_package_version }
+                onLinkClick={ this.closeMenu }
+              />
+              <Navigation onLinkClick={ this.closeNavigation } />
+            </div>
+            <div className={ css.body }>
+              <Wrapper className={ css.wrapper }>
+                <Switch>
+                  <Route exact path="/" component={ Introduction } />
+                  <Route path="/design/colors" component={ Colors } />
+                  <Route path="/design/typography" component={ Typography } />
+                  <Route path="/design/iconography" component={ Iconography } />
 
-                <Patterns />
+                  <Patterns />
 
-                <Route component={ FourOhFour } />
-              </Switch>
-            </Wrapper>
+                  <Route component={ FourOhFour } />
+                </Switch>
+              </Wrapper>
+            </div>
           </div>
-        </div>
+        </ScrollToTop>
       </BrowserRouter>
     );
   }

--- a/styleguide/components/ScrollToTop/ScrollToTop.js
+++ b/styleguide/components/ScrollToTop/ScrollToTop.js
@@ -1,0 +1,29 @@
+/*
+  global
+  window: true,
+ */
+
+import { Component, PropTypes } from 'react';
+import { withRouter } from 'react-router-dom';
+
+/**
+ * https://reacttraining.com/react-router/web/guides/scroll-restoration
+ */
+class ScrollToTop extends Component {
+  static propTypes = {
+    location: PropTypes.object,
+    children: PropTypes.node,
+  };
+
+  componentDidUpdate(prevProps) {
+    if (this.props.location !== prevProps.location) {
+      window.scrollTo(0, 0);
+    }
+  }
+
+  render() {
+    return this.props.children;
+  }
+}
+
+export default withRouter(ScrollToTop);


### PR DESCRIPTION
Makes the style guide reset the scroll position to the top of the window when the application's location is updated