### PR TITLE
Fix style guide's specimen component code sample overflowing on small screens

### DIFF
--- a/styleguide/components/Specimen/Specimen.css
+++ b/styleguide/components/Specimen/Specimen.css
@@ -5,6 +5,11 @@
   border-radius: 4px;
 }
 
+.specimenContainer {
+  position: relative;
+  z-index: 1;
+}
+
 .body {
   border-top: 1px solid var(--color-greyLighter);
   text-align: left;
@@ -36,8 +41,13 @@
   margin-top: var(--size-sm-iii);
 }
 
-.name + .pre,
-.attributes + .pre {
+.codeBlock {
+  overflow-x: scroll;
+  -webkit-overflow-scroll: smooth;
+}
+
+.name + .codeBlock,
+.attributes + .codeBlock {
   margin-top: var(--size-sm-iii);
 }
 

--- a/styleguide/components/Specimen/Specimen.js
+++ b/styleguide/components/Specimen/Specimen.js
@@ -76,12 +76,14 @@ export default class Specimen extends Component {
             </ul>
           ) }
           { code && (
-            <pre className={ css.pre }>
-              <code
-                className={ css.code }
-                dangerouslySetInnerHTML={ this.createMarkup() }
-              />
-            </pre>
+            <div className={ css.codeBlock }>
+              <pre className={ css.pre }>
+                <code
+                  className={ css.code }
+                  dangerouslySetInnerHTML={ this.createMarkup() }
+                />
+              </pre>
+            </div>
           ) }
         </div>
       </div>


### PR DESCRIPTION
On smaller screens, when the code sample's line is too long, the text overflows the container and causes the page to scroll. This forces scroll on the container itself, so the text is contained within it, and the user can scroll each code sample individually.