### PR TITLE
Fix specimen component z-index issue

### DIFF
--- a/globals/z-index.css
+++ b/globals/z-index.css
@@ -28,4 +28,8 @@
   --z-mapCanvas: var(--z-1);
   --z-mapMarker: var(--z-2);
   --z-mapControls: var(--z-3);
+
+  /* Style guide aliases */
+  --z-offcanvasPanel: var(--z-7);
+  --z-overlay: var(--z-7);
 }

--- a/styleguide/components/OffCanvasPanel/OffCanvasPanel.css
+++ b/styleguide/components/OffCanvasPanel/OffCanvasPanel.css
@@ -5,6 +5,7 @@
   right: 0;
   bottom: 0;
   opacity: 0;
+  z-index: var(--z-overlay);
   background-color: var(--overlay-default);
 }
 
@@ -13,7 +14,7 @@
   top: 0;
   left: 0;
   height: 100%;
-  z-index: 1;
+  z-index: var(--z-offcanvasPanel);
   overflow-y: scroll;
   width: 100%;
   max-width: 20rem;


### PR DESCRIPTION
Prevent the style guide's off screen navigation overlay from sitting below the specimen component.

### Before

<img width="475" alt="screen shot 2017-09-28 at 11 27 54" src="https://user-images.githubusercontent.com/2162181/30962054-29d33190-a440-11e7-9c7a-2291c742b3a5.png">

### After

<img width="475" alt="screen shot 2017-09-28 at 11 27 34" src="https://user-images.githubusercontent.com/2162181/30962057-2ca92a14-a440-11e7-9467-08e1afa0ee21.png">
