### PR TITLE
Disable storybook and prevent access in production

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,13 +129,11 @@
   },
   "scripts": {
     "build": "node scripts/build.js",
-    "build-storybook": "build-storybook",
-    "heroku-postbuild": "yarn build && yarn run build-storybook;",
+    "heroku-postbuild": "yarn build",
     "lint": "esw -c ./config/eslint.js ./components",
     "lint:watch": "esw -w -c ./config/eslint.js ./components",
     "serve": "node ./server",
     "start": "node scripts/start.js",
-    "storybook": "start-storybook -p 9009",
     "test": "jest --env=jsdom",
     "test:travis": "jest --env=jsdom --coverage",
     "test:watch": "jest --watch --notify --env=jsdom"

--- a/server/server.js
+++ b/server/server.js
@@ -4,7 +4,6 @@ import path from 'path';
 
 const app = express();
 
-app.use('/storybook', express.static(path.join(__dirname, '../storybook-static')));
 app.use('/static', express.static(path.join(__dirname, '../build/static')));
 app.use('*', (req, res) => {
   res.sendFile('index.html', { root: path.join(__dirname, '../build') });

--- a/styleguide/screens/Overview/introduction.md
+++ b/styleguide/screens/Overview/introduction.md
@@ -17,7 +17,3 @@ What this does mean however is it must be protected. Changes to Bloom must be ju
 ### Usage
 
 See [README.md](https://github.com/appearhere/bloom/blob/master/README.md).
-
-### Storybook
-
-To aide development, we also [maintain a set of stories](/storybook) using [Storybook](https://github.com/storybooks/storybook).


### PR DESCRIPTION
Temporarily removes storybook from Bloom, while I figure out how to upgrade it to `^3.x.x`. See https://github.com/storybooks/storybook/issues/2122 for more information