### PR TITLE
Upgrade to React 16

### DIFF
--- a/components/Calendar/DayPicker/DayPickerItem.test.js
+++ b/components/Calendar/DayPicker/DayPickerItem.test.js
@@ -2,7 +2,7 @@
 import React from 'react';
 import moment from 'moment';
 import { render, findDOMNode } from 'react-dom';
-import { Simulate } from 'react-addons-test-utils';
+import { Simulate } from 'react-dom/test-utils';
 import { ENTER } from '../../../constants/keycodes';
 
 import DayPickerItem from './DayPickerItem';

--- a/components/Dropdown/Dropdown.js
+++ b/components/Dropdown/Dropdown.js
@@ -1,43 +1,26 @@
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React from 'react';
 
 import Tether from '../Tether/Tether';
 import Inner from './DropdownInner';
 
 export { HORIZONTAL_ATTACHMENTS, VERTICAL_ATTACHMENTS } from '../Tether/Tether';
 
-export default class Dropdown extends Component {
-  static propTypes = {
-    target: PropTypes.node.isRequired,
-    children: PropTypes.node.isRequired,
-    className: PropTypes.string,
-    closeOnEsc: PropTypes.bool,
-    closeOnOutsideClick: PropTypes.bool,
-    onClose: PropTypes.func,
-  };
+const Dropdown = ({ target, children, className, ...rest }) => (
+  <Tether
+    { ...rest }
+    target={ target }
+  >
+    <Inner className={ className }>
+      { children }
+    </Inner>
+  </Tether>
+);
 
-  static defaultProps = {
-    closeOnEsc: true,
-    closeOnOutsideClick: true,
-  };
+Dropdown.propTypes = {
+  target: PropTypes.node.isRequired,
+  children: PropTypes.node.isRequired,
+  className: PropTypes.string,
+};
 
-  render() {
-    const {
-      target,
-      children,
-      className,
-      ...rest,
-    } = this.props;
-
-    return (
-      <Tether
-        { ...rest }
-        target={ target }
-      >
-        <Inner className={ className }>
-          { children }
-        </Inner>
-      </Tether>
-    );
-  }
-}
+export default Dropdown;

--- a/components/Form/InputField/InputField.test.js
+++ b/components/Form/InputField/InputField.test.js
@@ -3,15 +3,13 @@ import { render } from 'react-dom';
 
 import InputField from './InputField';
 
-const Input = () => <input />;
-
 it('renders without crashing', () => {
   const div = document.createElement('div');
   render(
     <InputField
       id=""
     >
-      <Input />
+      <input />
     </InputField>,
     div
   );

--- a/components/Form/Select/Select.test.js
+++ b/components/Form/Select/Select.test.js
@@ -1,6 +1,6 @@
 /* global jasmine:true */
 
-import { scryRenderedDOMComponentsWithTag, Simulate } from 'react-addons-test-utils';
+import { scryRenderedDOMComponentsWithTag, Simulate } from 'react-dom/test-utils';
 import React from 'react';
 import { render } from 'react-dom';
 

--- a/components/FunnelInputField/FunnelInputField.test.js
+++ b/components/FunnelInputField/FunnelInputField.test.js
@@ -3,15 +3,13 @@ import { render } from 'react-dom';
 
 import FunnelInputField from './FunnelInputField';
 
-const Input = () => <input />;
-
 it('renders without crashing', () => {
   const div = document.createElement('div');
   render(
     <FunnelInputField
       id=""
     >
-      <Input />
+      <input />
     </FunnelInputField>,
     div
   );

--- a/components/Icon/iconHelper.test.js
+++ b/components/Icon/iconHelper.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { isElement } from 'react-addons-test-utils';
+import { isElement } from 'react-dom/test-utils';
 
 import iconHelper from './iconHelper';
 

--- a/components/Modal/ModalAnimator.js
+++ b/components/Modal/ModalAnimator.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import cx from 'classnames';
 import uniqueId from 'lodash/fp/uniqueId';
-import Portal from 'react-portal';
+import { Portal } from 'react-portal';
 import { ESC } from '../../constants/keycodes';
 import noop from '../../utils/noop';
 import BodyClassNameConductor from '../../utils/BodyClassNameConductor/BodyClassNameConductor';
@@ -89,8 +89,10 @@ export default class ModalAnimator extends Component {
       windowClassName,
     } = this.props;
 
+    if (!active) return null;
+
     return (
-      <Portal isOpened={ active }>
+      <Portal>
         <div ref={ (c) => { this.modal = c; } } onClick={ this.handleClick }>
           <div className={ css.root }>
             <div className={ css.overlay } />

--- a/components/StickyNode/StickyNode.js
+++ b/components/StickyNode/StickyNode.js
@@ -18,7 +18,7 @@ import css from './StickyNode.css';
 
 const Sticky = ({ className, ...rest }) => {
   const classes = cx(css.root, className);
-  return <StickyNode {...rest} className={ classes } />;
+  return <StickyNode { ...rest } className={ classes } />;
 };
 
 Sticky.propTypes = {

--- a/components/StickyNode/StickyNode.test.js
+++ b/components/StickyNode/StickyNode.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+
 import StickyNode from './StickyNode';
 
 it('renders without crashing', () => {

--- a/components/Tabs/Tab.test.js
+++ b/components/Tabs/Tab.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { Simulate } from 'react-addons-test-utils';
+import { Simulate } from 'react-dom/test-utils';
 import Tab from './Tab';
 
 it('renders without crashing', () => {

--- a/components/Tether/Tether.js
+++ b/components/Tether/Tether.js
@@ -5,7 +5,7 @@ import React, { Component, cloneElement } from 'react';
 import { findDOMNode } from 'react-dom';
 import keyMirror from 'key-mirror';
 import { subscribe } from 'subscribe-ui-event';
-import Portal from 'react-portal';
+import { Portal } from 'react-portal';
 import cx from 'classnames';
 
 import css from './Tether.css';
@@ -375,11 +375,6 @@ export default class Tether extends Component {
       horizontalAttachment: _horziontalAttachment,
       flushHorizontal,
       flushVertical,
-      closeOnEsc,
-      closeOnOutsideClick,
-      beforeClose,
-      onClose,
-      onUpdate,
       targetClassName,
       ...rest,
     } = this.props;
@@ -405,31 +400,26 @@ export default class Tether extends Component {
             active,
           }) }
         </div>
-        <Portal
-          isOpened={ active }
-          closeOnEsc={ closeOnEsc }
-          closeOnOutsideClick={ closeOnOutsideClick }
-          beforeClose={ beforeClose }
-          onClose={ onClose }
-          onUpdate={ onUpdate }
-        >
-          <ChildWrapper
-            ref={ (c) => { this.component = findDOMNode(c); } }
-            style={ {
-              position: 'absolute',
-              top: `${top}px`,
-              left: `${left}px`,
-            } }
-          >
-            { cloneElement(children, {
-              verticalAttachment: topAttachment,
-              horizontalAttachment: leftAttachment,
-              flushHorizontal,
-              flushVertical,
-              active,
-            }) }
-          </ChildWrapper>
-        </Portal>
+        { active && (
+          <Portal>
+            <ChildWrapper
+              ref={ (c) => { this.component = findDOMNode(c); } }
+              style={ {
+                position: 'absolute',
+                top: `${top}px`,
+                left: `${left}px`,
+              } }
+            >
+              { cloneElement(children, {
+                verticalAttachment: topAttachment,
+                horizontalAttachment: leftAttachment,
+                flushHorizontal,
+                flushVertical,
+                active,
+              }) }
+            </ChildWrapper>
+          </Portal>
+        ) }
       </div>
     );
   }

--- a/components/Tether/test/Tether.test.js
+++ b/components/Tether/test/Tether.test.js
@@ -123,41 +123,6 @@ describe('Tether child component', () => {
     expect('flushHorizontal' in child.props).toBe(true);
     expect('flushVertical' in child.props).toBe(true);
   });
-
-  it('receives active prop from Tether', () => {
-    let child;
-
-    const div = document.createElement('div');
-    render(
-      <Tether
-        target={ <TestTarget /> }
-        active
-      >
-        <TestChild ref={ (c) => { child = c; } } />
-      </Tether>,
-      div
-    );
-
-    expect('active' in child.props).toBe(true);
-  });
-
-  it('receives closePortal prop from Portal', () => {
-    let child;
-
-    const div = document.createElement('div');
-    render(
-      <Tether
-        target={ <TestTarget /> }
-        active
-      >
-        <TestChild ref={ (c) => { child = c; } } />
-      </Tether>,
-      div
-    );
-
-    expect('closePortal' in child.props).toBe(true);
-    expect(typeof child.props.closePortal).toBe('function');
-  });
 });
 
 const OPTIMAL_ATTACHMENT_TEST_CASES = [

--- a/components/Video/Scrubber/Scrubber.test.js
+++ b/components/Video/Scrubber/Scrubber.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { findRenderedDOMComponentWithTag, Simulate } from 'react-addons-test-utils';
+import { findRenderedDOMComponentWithTag, Simulate } from 'react-dom/test-utils';
 
 import noop from '../../../utils/noop';
 import Scrubber from './Scrubber';

--- a/package.json
+++ b/package.json
@@ -74,9 +74,9 @@
     "postcss-custom-properties": "^6.2.0",
     "postcss-loader": "^2.0.8",
     "promise": "7.1.1",
+    "raf": "^3.4.0",
     "raw-loader": "^0.5.1",
-    "react-addons-test-utils": "^15.4.2",
-    "react-hot-loader": "^3.0.0-beta.3",
+    "react-hot-loader": "^3.1.3",
     "recursive-readdir": "2.0.0",
     "rimraf": "2.5.4",
     "strip-ansi": "3.0.1",
@@ -94,7 +94,7 @@
     "@appearhere/mapbox-gl": "^1.5.0",
     "@appearhere/nuka-carousel": "^2.2.0",
     "@appearhere/react-input-range": "^1.2.0",
-    "@appearhere/react-stickynode": "^1.0.0",
+    "@appearhere/react-stickynode": "^1.0.1",
     "array-from": "^2.1.1",
     "babel-polyfill": "^6.22.0",
     "classnames": "^2.2.5",
@@ -110,17 +110,17 @@
     "moment": "^2.17.1",
     "moment-range": "^3.0.2",
     "object-fit-images": "^2.5.9",
-    "react": "^15.6.2",
+    "react": "^16.1.1",
     "react-autosuggest": "^9.3.2",
     "react-autowhatever": "^10.1.0",
     "react-container-query": "^0.9.1",
     "react-dev-utils": "^4.1.0",
-    "react-dom": "15.6.2",
+    "react-dom": "^16.1.1",
     "react-html5video": "^2.5.0",
     "react-moment-proptypes": "^1.3.0",
     "react-motion": "^0.5.2",
     "react-on-visible": "^1.3.0",
-    "react-portal": "^3.1.0",
+    "react-portal": "^4.0.0",
     "react-router-dom": "^4.2.2",
     "react-transition-group": "1.x",
     "refractor": "^1.1.0",
@@ -159,7 +159,8 @@
       ".*": "<rootDir>/config/jest/transform.js"
     },
     "setupFiles": [
-      "<rootDir>/config/polyfills.js"
+      "<rootDir>/config/polyfills.js",
+      "raf/polyfill"
     ],
     "testPathIgnorePatterns": [
       "<rootDir>/(build|docs|node_modules)/"

--- a/styleguide/components/OffCanvasPanel/OffCanvasPanel.js
+++ b/styleguide/components/OffCanvasPanel/OffCanvasPanel.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { TransitionMotion, spring } from 'react-motion';
 import uniqueId from 'lodash/fp/uniqueId';
-import Portal from 'react-portal';
+import { Portal } from 'react-portal';
 
 import BtnContainer from '../../../components/BtnContainer/BtnContainer';
 import css from './OffCanvasPanel.css';
@@ -118,7 +118,7 @@ export default class OffCanvasPanel extends Component {
 
     /* eslint-disable jsx-a11y/no-static-element-interactions */
     return (
-      <Portal isOpened>
+      <Portal>
         <TransitionMotion
           styles={ active ? [{
             key: this.id,

--- a/styleguide/screens/Patterns/Dropdown/Dropdown.js
+++ b/styleguide/screens/Patterns/Dropdown/Dropdown.js
@@ -66,8 +66,6 @@ export default class DropdownDocumentation extends Component {
               flushHorizontal
               active={ showDropdown }
               targetClassName={ css.target }
-              closeOnEsc={ false }
-              closeOnOutsideClick={ false }
             >
               <button onClick={ this.handleClick }>Close dropdown</button>
             </Dropdown>

--- a/yarn.lock
+++ b/yarn.lock
@@ -44,9 +44,9 @@
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@appearhere/react-input-range/-/react-input-range-1.2.0.tgz#b0935d140a7318b6ff06571cd5d7affa1e021d69"
 
-"@appearhere/react-stickynode@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@appearhere/react-stickynode/-/react-stickynode-1.0.0.tgz#be116eb42f18413119ec3f8f71883bc3f3abd068"
+"@appearhere/react-stickynode@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@appearhere/react-stickynode/-/react-stickynode-1.0.1.tgz#45fa7ec9fad69de414a1e2dd473eafab50552aa4"
   dependencies:
     classnames "^2.0.0"
     prop-types "^15.6.0"
@@ -550,7 +550,7 @@ async-each@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.1.tgz#19d386a1d9edc6e7c1c85d388aedbcc56d33602d"
 
-async@^1.4.0, async@^1.4.2:
+async@^1.4.0:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
 
@@ -2139,7 +2139,7 @@ babel-runtime@6.x.x, babel-runtime@^6.0.0, babel-runtime@^6.11.6, babel-runtime@
     core-js "^2.4.0"
     regenerator-runtime "^0.10.0"
 
-babel-template@^6.14.0, babel-template@^6.15.0, babel-template@^6.16.0, babel-template@^6.7.0, babel-template@^6.8.0, babel-template@^6.9.0:
+babel-template@^6.14.0, babel-template@^6.15.0, babel-template@^6.16.0, babel-template@^6.8.0, babel-template@^6.9.0:
   version "6.16.0"
   resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.16.0.tgz#e149dd1a9f03a35f817ddbc4d0481988e7ebc8ca"
   dependencies:
@@ -2473,7 +2473,7 @@ browserslist@~1.3.5:
   dependencies:
     caniuse-db "^1.0.30000525"
 
-bser@^1.0.2:
+bser@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/bser/-/bser-1.0.2.tgz#381116970b2a6deea5646dd15dd7278444b56169"
   dependencies:
@@ -2717,6 +2717,10 @@ chokidar@^1.7.0:
     readdirp "^2.0.0"
   optionalDependencies:
     fsevents "^1.0.0"
+
+ci-info@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.1.2.tgz#03561259db48d0474c8bdc90f5b47b068b6bbfb4"
 
 cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
   version "1.0.4"
@@ -3108,7 +3112,7 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-create-react-class@^15.5.2, create-react-class@^15.6.0, create-react-class@^15.6.2:
+create-react-class@^15.5.2, create-react-class@^15.6.2:
   version "15.6.2"
   resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.6.2.tgz#cf1ed15f12aad7f14ef5f2dfe05e6c42f91ef02a"
   dependencies:
@@ -3327,6 +3331,12 @@ debug@^2.1.1, debug@^2.2.0, debug@~2.2.0:
   dependencies:
     ms "0.7.1"
 
+debug@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  dependencies:
+    ms "2.0.0"
+
 decamelize@^1.0.0, decamelize@^1.1.1, decamelize@^1.1.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
@@ -3435,8 +3445,8 @@ detect-port@1.0.0:
     commander "~2.8.1"
 
 diff@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-3.0.1.tgz#a52d90cc08956994be00877bff97110062582c35"
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-3.4.0.tgz#b1d85507daf3964828de54b37d0d73ba67dda56c"
 
 diffie-hellman@^5.0.0:
   version "5.0.2"
@@ -3894,7 +3904,7 @@ espree@^3.3.1:
     acorn "^4.0.1"
     acorn-jsx "^3.0.0"
 
-esprima@^2.6.0, esprima@^2.7.1, esprima@~2.7.0:
+esprima@^2.6.0, esprima@^2.7.1:
   version "2.7.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-2.7.3.tgz#96e3b70d5779f6ad49cd032673d1c312767ba581"
 
@@ -4186,10 +4196,10 @@ faye-websocket@~0.11.0:
     websocket-driver ">=0.5.1"
 
 fb-watchman@^1.8.0, fb-watchman@^1.9.0:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/fb-watchman/-/fb-watchman-1.9.0.tgz#6f268f1f347a6b3c875d1e89da7e1ed79adfc0ec"
+  version "1.9.2"
+  resolved "https://registry.yarnpkg.com/fb-watchman/-/fb-watchman-1.9.2.tgz#a24cf47827f82d38fb59a69ad70b76e3b6ae7383"
   dependencies:
-    bser "^1.0.2"
+    bser "1.0.2"
 
 fbjs@^0.8.12, fbjs@^0.8.16:
   version "0.8.16"
@@ -5214,8 +5224,10 @@ is-callable@^1.1.1, is-callable@^1.1.3:
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.3.tgz#86eb75392805ddc33af71c92a0eedf74ee7604b2"
 
 is-ci@^1.0.9:
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-1.0.9.tgz#de2c5ffe49ab3237fda38c47c8a3bbfd55bbcca7"
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-1.0.10.tgz#f739336b2632365061a9d48270cd56ae3369318e"
+  dependencies:
+    ci-info "^1.0.0"
 
 is-date-object@^1.0.1:
   version "1.0.1"
@@ -5442,32 +5454,48 @@ isstream@~0.1.2:
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
 
 istanbul-api@^1.1.0-alpha.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/istanbul-api/-/istanbul-api-1.1.1.tgz#d36e2f1560d1a43ce304c4ff7338182de61c8f73"
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/istanbul-api/-/istanbul-api-1.2.1.tgz#0c60a0515eb11c7d65c6b50bba2c6e999acd8620"
   dependencies:
     async "^2.1.4"
     fileset "^2.0.2"
-    istanbul-lib-coverage "^1.0.0"
-    istanbul-lib-hook "^1.0.0"
-    istanbul-lib-instrument "^1.3.0"
-    istanbul-lib-report "^1.0.0-alpha.3"
-    istanbul-lib-source-maps "^1.1.0"
-    istanbul-reports "^1.0.0"
+    istanbul-lib-coverage "^1.1.1"
+    istanbul-lib-hook "^1.1.0"
+    istanbul-lib-instrument "^1.9.1"
+    istanbul-lib-report "^1.1.2"
+    istanbul-lib-source-maps "^1.2.2"
+    istanbul-reports "^1.1.3"
     js-yaml "^3.7.0"
     mkdirp "^0.5.1"
     once "^1.4.0"
 
-istanbul-lib-coverage@^1.0.0, istanbul-lib-coverage@^1.0.0-alpha, istanbul-lib-coverage@^1.0.0-alpha.0:
+istanbul-lib-coverage@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-1.0.0.tgz#c3f9b6d226da12424064cce87fce0fb57fdfa7a2"
 
-istanbul-lib-hook@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-hook/-/istanbul-lib-hook-1.0.0.tgz#fc5367ee27f59268e8f060b0c7aaf051d9c425c5"
+istanbul-lib-coverage@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz#73bfb998885299415c93d38a3e9adf784a77a9da"
+
+istanbul-lib-hook@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-hook/-/istanbul-lib-hook-1.1.0.tgz#8538d970372cb3716d53e55523dd54b557a8d89b"
   dependencies:
     append-transform "^0.4.0"
 
-istanbul-lib-instrument@^1.1.1, istanbul-lib-instrument@^1.1.4:
+istanbul-lib-instrument@^1.1.1, istanbul-lib-instrument@^1.9.1:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-1.9.1.tgz#250b30b3531e5d3251299fdd64b0b2c9db6b558e"
+  dependencies:
+    babel-generator "^6.18.0"
+    babel-template "^6.16.0"
+    babel-traverse "^6.18.0"
+    babel-types "^6.18.0"
+    babylon "^6.18.0"
+    istanbul-lib-coverage "^1.1.1"
+    semver "^5.3.0"
+
+istanbul-lib-instrument@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-1.1.4.tgz#95be56e5c321456ffdfddc925ad4dcfc28edab9c"
   dependencies:
@@ -5478,7 +5506,7 @@ istanbul-lib-instrument@^1.1.1, istanbul-lib-instrument@^1.1.4:
     babylon "^6.8.1"
     istanbul-lib-coverage "^1.0.0"
 
-istanbul-lib-instrument@^1.3.0, istanbul-lib-instrument@^1.4.2:
+istanbul-lib-instrument@^1.4.2:
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-1.4.2.tgz#0e2fdfac93c1dabf2e31578637dc78a19089f43e"
   dependencies:
@@ -5490,29 +5518,28 @@ istanbul-lib-instrument@^1.3.0, istanbul-lib-instrument@^1.4.2:
     istanbul-lib-coverage "^1.0.0"
     semver "^5.3.0"
 
-istanbul-lib-report@^1.0.0-alpha.3:
-  version "1.0.0-alpha.3"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-1.0.0-alpha.3.tgz#32d5f6ec7f33ca3a602209e278b2e6ff143498af"
+istanbul-lib-report@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-1.1.2.tgz#922be27c13b9511b979bd1587359f69798c1d425"
   dependencies:
-    async "^1.4.2"
-    istanbul-lib-coverage "^1.0.0-alpha"
+    istanbul-lib-coverage "^1.1.1"
     mkdirp "^0.5.1"
     path-parse "^1.0.5"
-    rimraf "^2.4.3"
     supports-color "^3.1.2"
 
-istanbul-lib-source-maps@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.1.0.tgz#9d429218f35b823560ea300a96ff0c3bbdab785f"
+istanbul-lib-source-maps@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.2.tgz#750578602435f28a0c04ee6d7d9e0f2960e62c1c"
   dependencies:
-    istanbul-lib-coverage "^1.0.0-alpha.0"
+    debug "^3.1.0"
+    istanbul-lib-coverage "^1.1.1"
     mkdirp "^0.5.1"
-    rimraf "^2.4.4"
+    rimraf "^2.6.1"
     source-map "^0.5.3"
 
-istanbul-reports@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-1.0.1.tgz#9a17176bc4a6cbebdae52b2f15961d52fa623fbc"
+istanbul-reports@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-1.1.3.tgz#3b9e1e8defb6d18b1d425da8e8b32c5a163f2d10"
   dependencies:
     handlebars "^4.0.3"
 
@@ -5754,8 +5781,8 @@ jschardet@^1.4.2:
   resolved "https://registry.yarnpkg.com/jschardet/-/jschardet-1.5.1.tgz#c519f629f86b3a5bedba58a88d311309eec097f9"
 
 jsdom@^9.9.1:
-  version "9.10.0"
-  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-9.10.0.tgz#72d04d9fd5f1164d016dc350ef889af6d0d1a25a"
+  version "9.12.0"
+  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-9.12.0.tgz#e8c546fffcb06c00d4833ca84410fed7f8a097d4"
   dependencies:
     abab "^1.0.3"
     acorn "^4.0.4"
@@ -5772,7 +5799,7 @@ jsdom@^9.9.1:
     sax "^1.2.1"
     symbol-tree "^3.2.1"
     tough-cookie "^2.3.2"
-    webidl-conversions "^3.0.1"
+    webidl-conversions "^4.0.0"
     whatwg-encoding "^1.0.1"
     whatwg-url "^4.3.0"
     xml-name-validator "^2.0.1"
@@ -6104,6 +6131,10 @@ lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
 
+lodash.toarray@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.toarray/-/lodash.toarray-4.4.0.tgz#24c4bfcd6b2fba38bfd0594db1179d8e9b656561"
+
 lodash.words@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/lodash.words/-/lodash.words-3.2.0.tgz#4e2a8649bc08745b17c695b1a3ce8fee596623b3"
@@ -6201,14 +6232,14 @@ mapbox-gl-supported@^1.2.0:
   resolved "https://registry.yarnpkg.com/mapbox-gl-supported/-/mapbox-gl-supported-1.2.0.tgz#cbd34df894206cadda9a33c8d9a4609f26bb1989"
 
 marked-terminal@^1.6.2:
-  version "1.6.2"
-  resolved "https://registry.yarnpkg.com/marked-terminal/-/marked-terminal-1.6.2.tgz#44c128d69b5d9776c848314cdf69d4ec96322973"
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/marked-terminal/-/marked-terminal-1.7.0.tgz#c8c460881c772c7604b64367007ee5f77f125904"
   dependencies:
     cardinal "^1.0.0"
-    chalk "^1.0.0"
+    chalk "^1.1.3"
     cli-table "^0.3.1"
     lodash.assign "^4.2.0"
-    node-emoji "^1.3.1"
+    node-emoji "^1.4.1"
 
 marked@^0.3.6:
   version "0.3.6"
@@ -6471,11 +6502,11 @@ node-dir@^0.1.10:
   dependencies:
     minimatch "^3.0.2"
 
-node-emoji@^1.3.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/node-emoji/-/node-emoji-1.4.1.tgz#c9fa0cf91094335bcb967a6f42b2305c15af2ebc"
+node-emoji@^1.4.1:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/node-emoji/-/node-emoji-1.8.1.tgz#6eec6bfb07421e2148c75c6bba72421f8530a826"
   dependencies:
-    string.prototype.codepointat "^0.2.0"
+    lodash.toarray "^4.4.0"
 
 node-fetch@^1.0.1:
   version "1.6.3"
@@ -7530,6 +7561,12 @@ raf@^3.0.0, raf@^3.1.0:
   dependencies:
     performance-now "~0.2.0"
 
+raf@^3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.0.tgz#a28876881b4bc2ca9117d4138163ddb80f781575"
+  dependencies:
+    performance-now "^2.1.0"
+
 randomatic@^1.1.3:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/randomatic/-/randomatic-1.1.5.tgz#5e9ef5f2d573c67bd2b8124ae90b5156e457840b"
@@ -7619,9 +7656,9 @@ react-datetime@^2.10.3:
     prop-types "^15.5.7"
     react-onclickoutside "^6.5.0"
 
-react-deep-force-update@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/react-deep-force-update/-/react-deep-force-update-2.0.1.tgz#4f7f6c12c3e7de42f345992a3c518236fa1ecad3"
+react-deep-force-update@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/react-deep-force-update/-/react-deep-force-update-2.1.1.tgz#8ea4263cd6455a050b37445b3f08fd839d86e909"
 
 react-dev-utils@^4.1.0:
   version "4.1.0"
@@ -7658,18 +7695,18 @@ react-docgen@^2.15.0:
     node-dir "^0.1.10"
     recast "^0.12.6"
 
-react-dom@15.6.2:
-  version "15.6.2"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.6.2.tgz#41cfadf693b757faf2708443a1d1fd5a02bef730"
-  dependencies:
-    fbjs "^0.8.9"
-    loose-envify "^1.1.0"
-    object-assign "^4.1.0"
-    prop-types "^15.5.10"
-
 "react-dom@^15 || ^16":
   version "16.0.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.0.0.tgz#9cc3079c3dcd70d4c6e01b84aab2a7e34c303f58"
+  dependencies:
+    fbjs "^0.8.16"
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
+
+react-dom@^16.1.1:
+  version "16.1.1"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.1.1.tgz#b2e331b6d752faf1a2d31399969399a41d8d45f8"
   dependencies:
     fbjs "^0.8.16"
     loose-envify "^1.1.0"
@@ -7689,16 +7726,15 @@ react-error-overlay@^2.0.2:
     settle-promise "1.0.0"
     source-map "0.5.6"
 
-react-hot-loader@^3.0.0-beta.3:
-  version "3.0.0-beta.6"
-  resolved "https://registry.yarnpkg.com/react-hot-loader/-/react-hot-loader-3.0.0-beta.6.tgz#463fac0bfc8b63a8385258af20c91636abce75f4"
+react-hot-loader@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/react-hot-loader/-/react-hot-loader-3.1.3.tgz#6f92877326958c7cb0134b512474517869126082"
   dependencies:
-    babel-template "^6.7.0"
     global "^4.3.0"
-    react-deep-force-update "^2.0.1"
+    react-deep-force-update "^2.1.1"
     react-proxy "^3.0.0-alpha.0"
-    redbox-react "^1.2.5"
-    source-map "^0.4.4"
+    redbox-react "^1.3.6"
+    source-map "^0.6.1"
 
 react-html-attributes@^1.3.0:
   version "1.4.1"
@@ -7779,9 +7815,9 @@ react-onclickoutside@^6.5.0:
   version "6.6.3"
   resolved "https://registry.yarnpkg.com/react-onclickoutside/-/react-onclickoutside-6.6.3.tgz#f3b9226f4541039d6d5a4a6120c4dfffcf7de60c"
 
-react-portal@^3.1.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/react-portal/-/react-portal-3.2.0.tgz#4224e19b2b05d5cbe730a7ba0e34ec7585de0043"
+react-portal@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/react-portal/-/react-portal-4.0.0.tgz#d327b495dc72a305e8a3e351f212a2d94677f913"
   dependencies:
     prop-types "^15.5.8"
 
@@ -7885,15 +7921,14 @@ react-treebeard@^2.0.3:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
-react@^15.6.2:
-  version "15.6.2"
-  resolved "https://registry.yarnpkg.com/react/-/react-15.6.2.tgz#dba0434ab439cfe82f108f0f511663908179aa72"
+react@^16.1.1:
+  version "16.1.1"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.1.1.tgz#d5c4ef795507e3012282dd51261ff9c0e824fe1f"
   dependencies:
-    create-react-class "^15.6.0"
-    fbjs "^0.8.9"
+    fbjs "^0.8.16"
     loose-envify "^1.1.0"
-    object-assign "^4.1.0"
-    prop-types "^15.5.10"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
 
 reactcss@^1.2.0:
   version "1.2.2"
@@ -8038,18 +8073,20 @@ recursive-readdir@2.2.1:
   dependencies:
     minimatch "3.0.3"
 
-redbox-react@^1.2.5:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/redbox-react/-/redbox-react-1.3.2.tgz#bc12ca4f88705d29aaace7a12183d3ec14dd33f1"
+redbox-react@^1.3.6:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/redbox-react/-/redbox-react-1.5.0.tgz#04dab11557d26651bf3562a67c22ace56c5d3967"
   dependencies:
     error-stack-parser "^1.3.6"
     object-assign "^4.0.1"
+    prop-types "^15.5.4"
+    sourcemapped-stacktrace "^1.1.6"
 
 redeyed@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/redeyed/-/redeyed-1.0.0.tgz#6ce25045c9e1f9b28c0ae73ce2960c8cb48184b1"
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/redeyed/-/redeyed-1.0.1.tgz#e96c193b40c0816b00aec842698e61185e55498a"
   dependencies:
-    esprima "~2.7.0"
+    esprima "~3.0.0"
 
 reduce-css-calc@^1.2.6:
   version "1.3.0"
@@ -8305,9 +8342,15 @@ resolve@1.1.7, resolve@^1.1.6:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
 
-resolve@^1.1.5, resolve@^1.2.0:
+resolve@^1.1.5:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.2.0.tgz#9589c3f2f6149d1417a40becc1663db6ec6bc26c"
+
+resolve@^1.2.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.5.0.tgz#1f09acce796c9a762579f31b2c1cc4c3cddf9f36"
+  dependencies:
+    path-parse "^1.0.5"
 
 restore-cursor@^1.0.1:
   version "1.0.1"
@@ -8329,7 +8372,7 @@ right-align@^0.1.1:
   dependencies:
     align-text "^0.1.1"
 
-rimraf@2, rimraf@2.5.4, rimraf@^2.2.8, rimraf@^2.4.3, rimraf@^2.4.4, rimraf@~2.5.0, rimraf@~2.5.1:
+rimraf@2, rimraf@2.5.4, rimraf@^2.2.8, rimraf@~2.5.0, rimraf@~2.5.1:
   version "2.5.4"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.5.4.tgz#96800093cbf1a0c86bd95b4625467535c29dfa04"
   dependencies:
@@ -8407,9 +8450,13 @@ select@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/select/-/select-1.1.2.tgz#0e7350acdec80b1108528786ec1d4418d11b396d"
 
-"semver@2 || 3 || 4 || 5", semver@^5.1.0, semver@^5.3.0, semver@~5.3.0:
+"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@~5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
+
+semver@^5.1.0:
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.4.1.tgz#e059c09d8571f0540823733433505d3a2f00b18e"
 
 send@0.14.2:
   version "0.14.2"
@@ -8709,6 +8756,12 @@ source-map@~0.2.0:
   dependencies:
     amdefine ">=0.0.4"
 
+sourcemapped-stacktrace@^1.1.6:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/sourcemapped-stacktrace/-/sourcemapped-stacktrace-1.1.7.tgz#17e05374ff78b71a9d89ad3975a49f22725ba935"
+  dependencies:
+    source-map "0.5.6"
+
 space-separated-tokens@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/space-separated-tokens/-/space-separated-tokens-1.1.1.tgz#9695b9df9e65aec1811d4c3f9ce52520bc2f7e4d"
@@ -8824,10 +8877,6 @@ string-width@^2.1.0:
   dependencies:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
-
-string.prototype.codepointat@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/string.prototype.codepointat/-/string.prototype.codepointat-0.2.0.tgz#6b26e9bd3afcaa7be3b4269b526de1b82000ac78"
 
 string.prototype.padend@^3.0.0:
   version "3.0.0"
@@ -9042,8 +9091,8 @@ text-table@0.2.0, text-table@~0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
 
 throat@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/throat/-/throat-3.0.0.tgz#e7c64c867cbb3845f10877642f7b60055b8ec0d6"
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/throat/-/throat-3.2.0.tgz#50cb0670edbc40237b9e347d7e1f88e4620af836"
 
 through2@^2.0.0, through2@^2.0.3:
   version "2.0.3"
@@ -9525,9 +9574,13 @@ watchpack@^1.3.1, watchpack@^1.4.0:
     chokidar "^1.7.0"
     graceful-fs "^4.1.2"
 
-webidl-conversions@^3.0.0, webidl-conversions@^3.0.1:
+webidl-conversions@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+
+webidl-conversions@^4.0.0:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
 
 webpack-combine-loaders@^2.0.0:
   version "2.0.0"
@@ -9702,17 +9755,17 @@ which-module@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
 
-which@^1.0.5, which@^1.1.1, which@^1.2.9:
-  version "1.2.11"
-  resolved "https://registry.yarnpkg.com/which/-/which-1.2.11.tgz#c8b2eeea6b8c1659fa7c1dd4fdaabe9533dc5e8b"
-  dependencies:
-    isexe "^1.1.1"
-
-which@^1.2.14:
+which@^1.0.5, which@^1.1.1, which@^1.2.14:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.0.tgz#ff04bdfc010ee547d780bec38e1ac1c2777d253a"
   dependencies:
     isexe "^2.0.0"
+
+which@^1.2.9:
+  version "1.2.11"
+  resolved "https://registry.yarnpkg.com/which/-/which-1.2.11.tgz#c8b2eeea6b8c1659fa7c1dd4fdaabe9533dc5e8b"
+  dependencies:
+    isexe "^1.1.1"
 
 wide-align@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
* Remove [react-addons-test-utils](https://www.npmjs.com/package/react-addons-test-utils)
* Upgrade [react-portal](https://github.com/tajo/react-portal)
  * Use stateless portal in `<Tether />` and `<Modal />`
  * Rewrite `<Modal />` to return active as portal no longer accepts
  active prop
  * Remove unsupported portal props from `<Dropdown />`
  * Remove unsupported portal props from `<OffCanvasPanel />`
* Upgrade [react-hot-loader](https://github.com/gaearon/react-hot-loader) to stable version
* Upgrade [@appearhere/react-stickynode](https://github.com/appearhere/react-stickynode)
* Install [raf](https://github.com/chrisdickinson/raf) poylfill for jest