### PR TITLE
Use proper symbol for square meters

### DIFF
--- a/components/AreaUnits/AreaUnits.js
+++ b/components/AreaUnits/AreaUnits.js
@@ -11,7 +11,7 @@ const AreaUnits = ({ value, unit, className, ...rest }) => {
         className={ className }
       >
         { value }
-        m<sup>2</sup>
+        m&sup2;
       </span>
     );
     case AREA_UNITS.SQUARE_FOOT:


### PR DESCRIPTION
The `<sup />` tag creates issues with the line height of the parent element, `&sup2;` leverages the symbol shipped with the font.