### PR TITLE
Move analytics to gtag without react-ga

### DIFF
--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -1,5 +1,6 @@
 const CaseSensitivePathsPlugin = require('case-sensitive-paths-webpack-plugin');
 const env = require('./env');
+const InterpolateHtmlPlugin = require('react-dev-utils/InterpolateHtmlPlugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const path = require('path');
 const webpack = require('webpack');
@@ -116,6 +117,9 @@ module.exports = {
     }],
   },
   plugins: [
+    new InterpolateHtmlPlugin({
+      'GA_TRACKING_ID': process.env.GA_TRACKING_ID,
+    }),
     new HtmlWebpackPlugin({
       inject: true,
       template: paths.appHtml,

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -1,4 +1,5 @@
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
+const InterpolateHtmlPlugin = require('react-dev-utils/InterpolateHtmlPlugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const path = require('path');
 const url = require('url');
@@ -127,6 +128,9 @@ module.exports = {
     }],
   },
   plugins: [
+    new InterpolateHtmlPlugin({
+      'GA_TRACKING_ID': process.env.GA_TRACKING_ID,
+    }),
     new HtmlWebpackPlugin({
       inject: true,
       template: paths.appHtml,

--- a/index.html
+++ b/index.html
@@ -5,6 +5,16 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="shortcut icon" href="https://a0.ah-assets.net/assets/favicon-a6ae96bf51cbe3931878942469db2ecafc9f68d6f9c94c5d2b407584bd518a7f.ico">
     <title>Bloom | Appear Here's style guide</title>
+
+    <script async src="https://www.googletagmanager.com/gtag/js?id=%GA_TRACKING_ID%"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', '%GA_TRACKING_ID%');
+    </script>
+
     <script type="text/javascript" src="//fast.fonts.net/jsapi/e48efbf8-a486-4eb1-ba99-28266998779c.js"></script>
     <link href="https://fonts.googleapis.com/css?family=Fira+Mono" rel="stylesheet">
     <link rel="stylesheet"

--- a/package.json
+++ b/package.json
@@ -116,7 +116,6 @@
     "react-container-query": "^0.9.1",
     "react-dev-utils": "^4.1.0",
     "react-dom": "^16.1.1",
-    "react-ga": "^2.4.1",
     "react-html5video": "^2.5.0",
     "react-moment-proptypes": "^1.3.0",
     "react-motion": "^0.5.2",

--- a/styleguide/Styleguide.js
+++ b/styleguide/Styleguide.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import { BrowserRouter, Switch, Route } from 'react-router-dom';
-import GA from 'react-ga';
 
 import SiteHeader from './components/SiteHeader/SiteHeader';
 import Navigation from './components/Navigation/Navigation';
@@ -24,10 +23,6 @@ import Modifiers from './screens/Utilities/Modifiers';
 import FourOhFour from './404';
 
 import css from './Styleguide.css';
-
-GA.initialize(process.env.GA_TRACKING_ID, {
-  debug: process.env.NODE_ENV === 'development',
-});
 
 export default class Styleguide extends Component {
   constructor(props) {

--- a/styleguide/utils/GoogleAnalytics.js
+++ b/styleguide/utils/GoogleAnalytics.js
@@ -1,7 +1,8 @@
-import GA from 'react-ga';
-
 export default (props) => {
-  GA.set({ page: props.location.pathname + props.location.search });
-  GA.pageview(props.location.pathname + props.location.search);
+  if (typeof window.gtag !== 'undefined') {
+    window.gtag('config', process.env.GA_TRACKING_ID, {
+      page_path: props.location.pathname + props.location.search,
+    });
+  }
   return null;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -7711,13 +7711,6 @@ react-error-overlay@^2.0.2:
     settle-promise "1.0.0"
     source-map "0.5.6"
 
-react-ga@^2.4.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/react-ga/-/react-ga-2.4.1.tgz#dfbd5f028ed39a07067f7a8bf57dc0d240000767"
-  optionalDependencies:
-    prop-types "^15.6.0"
-    react "^15.6.2 || ^16.0"
-
 react-hot-loader@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/react-hot-loader/-/react-hot-loader-3.1.3.tgz#6f92877326958c7cb0134b512474517869126082"
@@ -7907,15 +7900,6 @@ react-treebeard@^2.0.3:
 "react@^15 || ^16":
   version "16.0.0"
   resolved "https://registry.yarnpkg.com/react/-/react-16.0.0.tgz#ce7df8f1941b036f02b2cca9dbd0cb1f0e855e2d"
-  dependencies:
-    fbjs "^0.8.16"
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.0"
-
-"react@^15.6.2 || ^16.0":
-  version "16.2.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.2.0.tgz#a31bd2dab89bff65d42134fa187f24d054c273ba"
   dependencies:
     fbjs "^0.8.16"
     loose-envify "^1.1.0"


### PR DESCRIPTION
`react-ga` is unneeded dependency which causes issues when exporting bloom library for react 16. We can use gtag default script to track pageviews.