### PR TITLE
Fix card animation glitch on Chrome and Opera

### DIFF
--- a/components/Cards/PictureCard/PictureCard.css
+++ b/components/Cards/PictureCard/PictureCard.css
@@ -21,7 +21,8 @@
   width: 100%;
   height: 100%;
   background-color: var(--overlay-default);
-  transition: all 200ms;
+  transition: opacity 200ms;
+  will-change: opacity;
   opacity: 1;
   position: absolute;
   top: 0;


### PR DESCRIPTION
The opacity transition of the picture card is making the embedded svg glitchy. Adding `will-change: opacity` should make it more stable.