### PR TITLE
Bug/onclick of destination listing fires twice

### DIFF
--- a/components/Cards/DestinationListingCard/DestinationListingCard.js
+++ b/components/Cards/DestinationListingCard/DestinationListingCard.js
@@ -104,6 +104,7 @@ export default class DestinationListingCard extends Component {
       children,
       onFavouriteClick,
       onCarouselChange,
+      onClick,
       favourite,
       favouriteable,
       ...rest


### PR DESCRIPTION
## Problem
The `onClick` function given as prop is being called twice when clicking on a link.

## Solution
Make sure `onClick` is not in `rest`, as everything in `rest` gets attached to the container. We only want the `onClick` to be called when the link itself is clicked, not the container.