### PR TITLE
PG-1849 Open links in DestinationListingCard in new tab

### DIFF
--- a/packages/core/src/components/Cards/DestinationListingCard/DestinationListingCard.js
+++ b/packages/core/src/components/Cards/DestinationListingCard/DestinationListingCard.js
@@ -40,6 +40,7 @@ export default class DestinationListingCard extends Component {
     onCarouselChange: PropTypes.func,
     favourite: PropTypes.bool,
     favouriteable: PropTypes.bool,
+    target: PropTypes.oneOf(['_self', '_blank', '_parent', '_top']),
   };
 
   static defaultProps = {
@@ -52,6 +53,7 @@ export default class DestinationListingCard extends Component {
     onClick: noop,
     onFavouriteClick: noop,
     onCarouselChange: noop,
+    target: '_self',
   };
 
   state = {
@@ -107,6 +109,7 @@ export default class DestinationListingCard extends Component {
       onClick,
       favourite,
       favouriteable,
+      target,
       ...rest
     } = this.props;
 
@@ -145,7 +148,7 @@ export default class DestinationListingCard extends Component {
               onChange={onCarouselChange}
             >
               {images.map(({ src, ...imageProps }) => (
-                <a href={href} key={src} onClick={this.onClick} target="_blank">
+                <a href={href} key={src} onClick={this.onClick} target={target}>
                   <div className={css.imageContainer}>
                     <FittedImage className={css.image} src={src} {...imageProps} />
                   </div>
@@ -155,7 +158,7 @@ export default class DestinationListingCard extends Component {
           </div>
         </div>
         <div className={cx(css.body, bodyClassName)}>
-          <a href={href} onClick={this.onClick} className={css.bodyLink} target="_blank">
+          <a href={href} onClick={this.onClick} className={css.bodyLink} target={target}>
             <div className={css.title}>
               <div className={css.priceContainer}>
                 { priceFromLabel &&

--- a/packages/core/src/components/Cards/DestinationListingCard/DestinationListingCard.js
+++ b/packages/core/src/components/Cards/DestinationListingCard/DestinationListingCard.js
@@ -145,7 +145,7 @@ export default class DestinationListingCard extends Component {
               onChange={onCarouselChange}
             >
               {images.map(({ src, ...imageProps }) => (
-                <a href={href} key={src} onClick={this.onClick}>
+                <a href={href} key={src} onClick={this.onClick} target="_blank">
                   <div className={css.imageContainer}>
                     <FittedImage className={css.image} src={src} {...imageProps} />
                   </div>
@@ -155,7 +155,7 @@ export default class DestinationListingCard extends Component {
           </div>
         </div>
         <div className={cx(css.body, bodyClassName)}>
-          <a href={href} onClick={this.onClick} className={css.bodyLink}>
+          <a href={href} onClick={this.onClick} className={css.bodyLink} target="_blank">
             <div className={css.title}>
               <div className={css.priceContainer}>
                 { priceFromLabel &&


### PR DESCRIPTION
This component is only being used as part of the `SpaceListingCard` which is used to display the space listing cards within the search results. 

This PR changes the target attribute within links in this component so as to open in a new tab instead of redirecting the user. 