### PR TITLE
Modify DestinationListingCard

### DIFF
--- a/packages/core/src/components/Cards/DestinationListingCard/DestinationListingCard.css
+++ b/packages/core/src/components/Cards/DestinationListingCard/DestinationListingCard.css
@@ -218,3 +218,7 @@
 .additionalInformationBadge {
   margin-right: 8px;
 }
+
+.special {
+  color: var(--color-gold);
+}

--- a/packages/core/src/components/Cards/DestinationListingCard/DestinationListingCard.css
+++ b/packages/core/src/components/Cards/DestinationListingCard/DestinationListingCard.css
@@ -200,7 +200,8 @@
   composes: fontSmallI from '../../../globals/typography.css';
   color: var(--color-grey);
   margin-top: var(--size-sm-ii);
-  display: block;
+  display: flex;
+  align-items: center;
 }
 
 .additionalInformationItem {
@@ -208,4 +209,12 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.additionalInformationText {
+  display: flex;
+}
+
+.additionalInformationBadge {
+  margin-right: 8px;
 }

--- a/packages/core/src/components/Cards/DestinationListingCard/DestinationListingCard.js
+++ b/packages/core/src/components/Cards/DestinationListingCard/DestinationListingCard.js
@@ -41,6 +41,7 @@ export default class DestinationListingCard extends Component {
     favourite: PropTypes.bool,
     favouriteable: PropTypes.bool,
     target: PropTypes.oneOf(['_self', '_blank', '_parent', '_top']),
+    variant: PropTypes.oneOf(['default', 'special']),
   };
 
   static defaultProps = {
@@ -54,6 +55,7 @@ export default class DestinationListingCard extends Component {
     onFavouriteClick: noop,
     onCarouselChange: noop,
     target: '_self',
+    variant: 'default',
   };
 
   state = {
@@ -110,6 +112,7 @@ export default class DestinationListingCard extends Component {
       favourite,
       favouriteable,
       target,
+      variant,
       ...rest
     } = this.props;
 
@@ -181,7 +184,7 @@ export default class DestinationListingCard extends Component {
                  { badge }
                 </div>
               }
-              <div className={cx(css.additionalInformationText, css[context])}>
+              <div className={cx(css.additionalInformationText, css[variant])}>
                 {
                   information
                     .filter(info => info)

--- a/packages/core/src/components/Cards/DestinationListingCard/DestinationListingCard.js
+++ b/packages/core/src/components/Cards/DestinationListingCard/DestinationListingCard.js
@@ -173,37 +173,43 @@ export default class DestinationListingCard extends Component {
                   { priceUnit }
                 </span>
               </div>
-              { badge }
             </div>
             <div className={css.name}>{ name }</div>
             <div className={css.additionalInformationBlock}>
-              {
-                information
-                  .filter(info => info)
-                  .map(info => <span>{ info }</span>)
-                  .reduce((accu, elem, i, arr) => {
-                    const wrappedEl = (
-                      <span
-                        key={`info-${i}`}
-                        className={css.additionalInformationItem}
-                        style={{
-                          maxWidth: `calc(${100 / arr.length}% - 1rem)`,
-                        }}
-                      >
-                        { elem }
-                      </span>
-                    );
-                    const spacer = (
-                      <span key={`info-spacer-${i}`} className={css.spacer}>•</span>
-                    );
-
-                    return accu === null
-                      ? [wrappedEl]
-                      : [...accu, spacer, wrappedEl];
-                  },
-                    null,
-                  )
+              {badge &&
+                <div className={css.additionalInformationBadge}>
+                 { badge }
+                </div>
               }
+              <div className={cx(css.additionalInformationText, css[context])}>
+                {
+                  information
+                    .filter(info => info)
+                    .map(info => <span>{ info }</span>)
+                    .reduce((accu, elem, i, arr) => {
+                      const wrappedEl = (
+                        <span
+                          key={`info-${i}`}
+                          className={css.additionalInformationItem}
+                          style={{
+                            maxWidth: `calc(${100 / arr.length}% - 1rem)`,
+                          }}
+                        >
+                          { elem }
+                        </span>
+                      );
+                      const spacer = (
+                        <span key={`info-spacer-${i}`} className={css.spacer}>•</span>
+                      );
+
+                      return accu === null
+                        ? [wrappedEl]
+                        : [...accu, spacer, wrappedEl];
+                    },
+                      null,
+                    )
+                }
+              </div>
             </div>
           </a>
           { children && (

--- a/packages/playground/stories/Cards.story.js
+++ b/packages/playground/stories/Cards.story.js
@@ -72,6 +72,35 @@ storiesOf('Cards', module)
       href="#"
     />
   ))
+  .add('SpaceListingCard - Special variant', () => (
+    <SpaceListingCard
+      price="$10,000,000"
+      priceUnit="/day"
+      location="Shoreditch, London in the Greater London Area"
+      size="1000 sqft"
+      name="A really long Bold Street Shop, maybe the biggest shop you've ever seen"
+      images={[
+        {
+          src: 'https://source.unsplash.com/random/500x500',
+          alt: 'hello',
+        },
+        {
+          src: 'https://source.unsplash.com/random/500x503',
+          alt: 'hello2',
+        },
+        {
+          src: 'https://source.unsplash.com/random/500x502',
+          alt: 'hello',
+        },
+        {
+          src: 'https://source.unsplash.com/random/500x501',
+          alt: 'hello2',
+        },
+      ]}
+      href="#"
+      variant="special"
+    />
+  ))
   .add('SpaceListingCard with badge', () => (
     <SpaceListingCard
       price="$10,000,00000000000000000000000"


### PR DESCRIPTION
This PR makes two changes to the DestinationListingCard component: 

1) Moving the positioning of the `badge` prop. The previous positioning does not have any use case anymore and we seem to be positioning badges in a different fixed place in current designs. 

2) Creating a Special variant for the DestinationListingCard - the difference between this and the default variant is that the colour of the additional information font is gold. 
