### PR TITLE
Fix DestinationListingCard text width

### DIFF
--- a/packages/core/src/components/Cards/DestinationListingCard/DestinationListingCard.css
+++ b/packages/core/src/components/Cards/DestinationListingCard/DestinationListingCard.css
@@ -213,6 +213,7 @@
 
 .additionalInformationText {
   display: flex;
+  flex: 1;
 }
 
 .additionalInformationBadge {


### PR DESCRIPTION
The changes in the last version update to the DestinationListingCard affected the display width of the `additionalInformationText` content where it was cutting it off. 

This fixes that by setting a flex value.