### PR TITLE
Fixing left content sizing bug with collapsible panel

### DIFF
--- a/packages/core/src/components/CollapsibleRow/CollapsibleRow.css
+++ b/packages/core/src/components/CollapsibleRow/CollapsibleRow.css
@@ -21,8 +21,8 @@
 
 .left {
   padding: 1rem;
-  width: 56px;
-  box-sizing: border-box;
+  width: 1.5rem;
+  box-sizing: content-box;
 }
 
 .right {


### PR DESCRIPTION
Updated left content in collapsible panel to use content-box instead of border-box