### PR TITLE
PG-2105 add subtext to calendaritem

### DIFF
--- a/packages/core/src/components/Calendar/CalendarItem/CalendarItem.css
+++ b/packages/core/src/components/Calendar/CalendarItem/CalendarItem.css
@@ -18,3 +18,9 @@
   text-decoration: line-through;
   color: var(--color-greyLight);
 }
+
+.subtext p {
+  color: var(--color-grey);
+  font-size: 0.5625rem;
+  margin: 0.2rem 0 0;
+}

--- a/packages/core/src/components/Calendar/CalendarItem/CalendarItem.js
+++ b/packages/core/src/components/Calendar/CalendarItem/CalendarItem.js
@@ -16,7 +16,7 @@ export const defaultClassNames = {
 };
 
 const CalendarDay = props => {
-  const { day, format, className, dayClassName, classNames, today, outOfRange, isClosed, ...rest } = props;
+  const { day, format, className, dayClassName, classNames, today, outOfRange, isClosed, subtext, ...rest } = props;
 
   const classes = cx(
     classNames.root,
@@ -29,6 +29,11 @@ const CalendarDay = props => {
   return day ? (
     <div {...rest} className={classes}>
       <span className={dayClassName}>{day.format(format)}</span>
+        {subtext &&
+          <div className={css.subtext}>
+            <p>{subtext}</p>
+          </div>
+        }
     </div>
   ) : (
     <div className={classes}>{'\u00a0'}</div>
@@ -44,6 +49,7 @@ CalendarDay.propTypes = {
   today: PropTypes.bool,
   outOfRange: PropTypes.bool,
   isClosed: PropTypes.bool,
+  subtext: PropTypes.string,
 };
 
 CalendarDay.defaultProps = {

--- a/packages/core/src/components/Calendar/CalendarItem/CalendarItem.test.js
+++ b/packages/core/src/components/Calendar/CalendarItem/CalendarItem.test.js
@@ -12,3 +12,8 @@ it('renders without a date without crashing', () => {
   const div = document.createElement('div');
   render(<CalendarItem day={null} />, div);
 });
+
+it('renders with a subtext without crashing', () => {
+  const div = document.createElement('div');
+  render(<CalendarItem subtext={'£1000'} />, div);
+});

--- a/packages/core/src/components/Calendar/DayPicker/DayPickerItem.js
+++ b/packages/core/src/components/Calendar/DayPicker/DayPickerItem.js
@@ -17,6 +17,7 @@ export const defaultDayState = {
   isHighlighted: false,
   isFirstHighlighted: false,
   isLastHighlighted: false,
+  subtext: undefined,
 };
 
 const defaultGetDateState = () => defaultDayState;
@@ -103,6 +104,7 @@ export default class DayPickerItem extends Component {
         tabIndex={0}
         className={className}
         day={day}
+        subtext={state.subtext}
       />
     );
   }


### PR DESCRIPTION
We needed to display the prices for each day on the bloom calendar. To make this as reusable as possible, I called it subtext, as the text is greyed out and below the main day text.