### PR TITLE
PG-2015 fix calendar day padding

### DIFF
--- a/packages/core/src/components/Calendar/CalendarItem/CalendarItem.css
+++ b/packages/core/src/components/Calendar/CalendarItem/CalendarItem.css
@@ -2,7 +2,7 @@
   composes: fontRegular from '../../../globals/typography.css';
   display: block;
   width: 100%;
-  padding: var(--size-small);
+  padding: 0.5rem 0;
   text-align: center;
 }
 


### PR DESCRIPTION
When the subtext given to the calendar was too big, it was becoming offcenter. This padding fix removes that issue.