### PR TITLE
Adding new ScreenSize component

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -74,6 +74,7 @@
     "eslint-plugin-react": "^7.4.0",
     "identity-obj-proxy": "^3.0.0",
     "lost": "^8.2.1",
+    "mutationobserver-shim": "^0.3.3",
     "postcss-cssnext": "^3.1.0",
     "postcss-custom-media": "^6.0.0",
     "postcss-custom-properties": "^7.0.0",

--- a/packages/core/src/components/ScreenSize/ScreenSize.js
+++ b/packages/core/src/components/ScreenSize/ScreenSize.js
@@ -1,0 +1,36 @@
+import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import ExecutionEnvironment from 'exenv';
+
+const ScreenSize = ({ tabletSize = 48, desktopSize = 64, render }) => {
+  const getSize = () => {
+    if (!ExecutionEnvironment.canUseDOM) {
+      return;
+    }
+    return {
+      isMobile: window.matchMedia(`(max-width: ${tabletSize - 0.0625}rem)`).matches,
+      isTablet: window.matchMedia(`(min-width: ${tabletSize}rem) and (max-width: ${desktopSize - 0.0625}rem)`).matches,
+      isDesktop: window.matchMedia(`(min-width: ${desktopSize}rem)`).matches,
+    };
+  }
+
+  const [size, setSize] = useState(getSize());
+
+  useEffect(() => {
+    const handleResize = () => setSize(getSize());
+    window.addEventListener('resize', handleResize);
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  });
+
+  return render(size)
+};
+
+ScreenSize.propTypes = {
+  tabletSize: PropTypes.number,
+  desktopSize: PropTypes.number,
+  render: PropTypes.func,
+}
+
+export default ScreenSize;

--- a/packages/core/src/components/ScreenSize/ScreenSize.test.js
+++ b/packages/core/src/components/ScreenSize/ScreenSize.test.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import 'mutationobserver-shim';
+
+window.matchMedia = jest.fn().mockImplementation(query => {
+  return {
+    matches: false,
+  };
+});
+
+import ScreenSize from './ScreenSize';
+
+it('renders without crashing', () => {
+  const { container } = render(
+    <ScreenSize render={({}) => (
+      <div />
+    )} />
+  );
+});

--- a/packages/core/src/components/index.js
+++ b/packages/core/src/components/index.js
@@ -224,3 +224,4 @@ export Wrapper from './Wrapper/Wrapper';
 export OptionCard from './OptionCard/OptionCard';
 export CollapsibleRow from './CollapsibleRow/CollapsibleRow';
 export CollapsibleProgressSteps from './CollapsibleProgressSteps/CollapsibleProgressSteps';
+export ScreenSize from './ScreenSize/ScreenSize';

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -95,6 +95,7 @@ export {
   OptionCard,
   CollapsibleRow,
   CollapsibleProgressSteps,
+  ScreenSize,
 } from './components/index.js';
 
 export Colors from './globals/colors.css';

--- a/yarn.lock
+++ b/yarn.lock
@@ -6889,6 +6889,18 @@ escape-string-regexp@1.0.5, escape-string-regexp@^1.0.0, escape-string-regexp@^1
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
+escodegen@^1.11.1:
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.12.0.tgz#f763daf840af172bb3a2b6dd7219c0e17f7ff541"
+  integrity sha512-TuA+EhsanGcme5T3R0L80u4t8CpbXQjegRmf7+FPTJrtCTErXFeelblRgHQa1FofEzqYYJmJ/OqjTwREp9qgmg==
+  dependencies:
+    esprima "^3.1.3"
+    estraverse "^4.2.0"
+    esutils "^2.0.2"
+    optionator "^0.8.1"
+  optionalDependencies:
+    source-map "~0.6.1"
+
 escodegen@^1.6.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.8.1.tgz#5a5b53af4693110bebb0867aa3430dd3b70a1018"
@@ -6900,7 +6912,7 @@ escodegen@^1.6.1:
   optionalDependencies:
     source-map "~0.2.0"
 
-escodegen@^1.8.1, escodegen@^1.9.0, escodegen@~1.9.0:
+escodegen@^1.9.0, escodegen@~1.9.0:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.9.1.tgz#dbae17ef96c8e4bedb1356f4504fa4cc2f7cb7e2"
   dependencies:
@@ -8437,9 +8449,9 @@ handle-thing@^2.0.0:
   integrity sha512-d4sze1JNC454Wdo2fkuyzCr6aHcbL6PGGuFAz0Li/NcOm1tCHGnWDRmJP85dh9IhQErTc2svWFEX5xHIOo//kQ==
 
 handlebars@^4.0.2, handlebars@^4.0.3, handlebars@^4.3.0:
-  version "4.5.2"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.5.2.tgz#5a4eb92ab5962ca3415ac188c86dc7f784f76a0f"
-  integrity sha512-29Zxv/cynYB7mkT1rVWQnV7mGX6v7H/miQ6dbEpYTKq5eJBN7PsRB+ViYJlcT6JINTSu4dVB9kOqEun78h6Exg==
+  version "4.5.3"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.5.3.tgz#5cf75bd8714f7605713511a56be7c349becb0482"
+  integrity sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==
   dependencies:
     neo-async "^2.6.0"
     optimist "^0.6.1"
@@ -11148,6 +11160,11 @@ multicast-dns@^6.0.1:
   dependencies:
     dns-packet "^1.3.1"
     thunky "^1.0.2"
+
+mutationobserver-shim@^0.3.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/mutationobserver-shim/-/mutationobserver-shim-0.3.3.tgz#65869630bc89d7bf8c9cd9cb82188cd955aacd2b"
+  integrity sha512-gciOLNN8Vsf7YzcqRjKzlAJ6y7e+B86u7i3KXes0xfxx/nfLmozlW1Vn+Sc9x3tPIePFgc1AeIFhtRgkqTjzDQ==
 
 mute-stream@0.0.7:
   version "0.0.7"
@@ -15289,11 +15306,11 @@ stack-utils@^1.0.1:
   resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.1.tgz#d4f33ab54e8e38778b0ca5cfd3b3afb12db68620"
 
 static-eval@^2.0.0, static-eval@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/static-eval/-/static-eval-2.0.2.tgz#2d1759306b1befa688938454c546b7871f806a42"
-  integrity sha512-N/D219Hcr2bPjLxPiV+TQE++Tsmrady7TqAJugLy7Xk1EumfDWS/f5dtBbkRCGE7wKKXuYockQoj8Rm2/pVKyg==
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/static-eval/-/static-eval-2.0.3.tgz#cb62fc79946bd4d5f623a45ad428233adace4d72"
+  integrity sha512-zsxDGucfAh8T339sSKgpFbvg15Fms2IVaJGC+jqp0bVsxhcpM+iMeAI8weNo8dmf4OblgifTBUoyk1vGVtYw2w==
   dependencies:
-    escodegen "^1.8.1"
+    escodegen "^1.11.1"
 
 static-extend@^0.1.1:
   version "0.1.2"


### PR DESCRIPTION
We Currently have a `withMobile` higher order component on the web project but I think this should be moved to Bloom.

I've created a `ScreenSize` render prop component using hooks which stores if the user is on mobile, tablet or desktop