### PR TITLE
Fix left-over onChange from nuka-carousel fork

### DIFF
--- a/packages/core/src/components/Cards/DestinationListingCard/DestinationListingCard.js
+++ b/packages/core/src/components/Cards/DestinationListingCard/DestinationListingCard.js
@@ -148,7 +148,7 @@ export default class DestinationListingCard extends Component {
               wrapAround
               swiping={false}
               dragging={false}
-              onChange={onCarouselChange}
+              afterSlide={onCarouselChange}
               withoutControls
             >
               {images.map(({ src, ...imageProps }) => (


### PR DESCRIPTION
We now use the original nuka carousel prop called afterSlide, which gives us the same arguments and fixes a problem where on clicking to load a next or previous image just did not trigger the callback, and therefore the image did not load.

Ticket: https://appearhere.atlassian.net/browse/PG-2283