### PR TITLE
Update District card to have object-fit and use smaller font

### DIFF
--- a/packages/core/src/components/Cards/DistrictCard/DistrictCard.css
+++ b/packages/core/src/components/Cards/DistrictCard/DistrictCard.css
@@ -21,6 +21,7 @@
 .image {
   width: 100%;
   height: 100%;
+  object-fit: cover;
 }
 
 .content {
@@ -41,7 +42,7 @@
 
 .subtitle {
   font-family: var(--font-avenir);
-  font-size: var(--font-small-i);
+  font-size: var(--fontsize-small-i);
   line-height: 1.43020625rem;
   color: var(--color-grey);
   margin: 0;


### PR DESCRIPTION
Update the district card component with the following:
- Image is now using `object-fit`
- Use a smaller fontsize for supporting copy
