### PR TITLE
Adding variant to success story mobile card

### DIFF
--- a/packages/core/src/components/Cards/SuccessStoryCard/SuccessStoryCardMobile.css
+++ b/packages/core/src/components/Cards/SuccessStoryCard/SuccessStoryCardMobile.css
@@ -1,6 +1,13 @@
 .successStoryCard {
-  background: var(--color-black);
   padding: 2rem 1.5rem;
+}
+
+.goldBackground {
+  background: var(--color-gold);
+}
+
+.blackBackground {
+  background: var(--color-greyDarkest);
 }
 
 .title {

--- a/packages/core/src/components/Cards/SuccessStoryCard/SuccessStoryCardMobile.js
+++ b/packages/core/src/components/Cards/SuccessStoryCard/SuccessStoryCardMobile.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import cx from 'classnames';
 import shortid from 'shortid';
 import FittedImage from '../../FittedImage/FittedImage';
 import Icon from '../../Icon/Icon';
@@ -7,8 +8,11 @@ import RemoveOrphans from '../../RemoveOrphans/RemoveOrphans';
 
 import css from './SuccessStoryCardMobile.css';
 
-const SuccessStoryCardMobile = ({title, imageSrc, copy, brands = [], href, brandsTitle}) => (
-  <div className={css.successStoryCard}>
+const SuccessStoryCardMobile = ({title, imageSrc, copy, brands = [], href, brandsTitle, variant}) => (
+  <div className={cx(css.successStoryCard, {
+    [css.goldBackground]: variant === 'gold',
+    [css.blackBackground]: variant === 'black',
+  })}>
     <h2 className={css.title}>
       <RemoveOrphans text={title} />
     </h2>
@@ -44,6 +48,10 @@ SuccessStoryCardMobile.propTypes = {
   brands: PropTypes.array.isRequired,
   href: PropTypes.string.isRequired,
   brandsTitle: PropTypes.string.isRequired,
+};
+
+SuccessStoryCardMobile.defaultProps = {
+  variant: 'black',
 };
 
 export default SuccessStoryCardMobile;


### PR DESCRIPTION
The desktop success story cards take a `variant`  prop which was missing on the mobile version