### PR TITLE
Feature: display multiple months in daypicker

### DIFF
--- a/packages/core/src/components/Calendar/DayPicker/DayPicker.css
+++ b/packages/core/src/components/Calendar/DayPicker/DayPicker.css
@@ -2,6 +2,15 @@
   position: relative;
   width: 100%;
   height: 100%;
+  display: flex;
+}
+
+.monthWrapper {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  margin-left: .25rem;
+  margin-right: .25rem;
 }
 
 .header {

--- a/packages/core/src/components/Calendar/DayPicker/DayPicker.js
+++ b/packages/core/src/components/Calendar/DayPicker/DayPicker.js
@@ -62,6 +62,7 @@ export default class DayPicker extends Component {
       root: '',
       header: '',
     },
+    maskSize: 1,
   };
 
   handleNextMonth = e => {
@@ -78,48 +79,59 @@ export default class DayPicker extends Component {
 
   render() {
     const {
-      month,
       dayProps,
       columnHeadingProps,
       onInteraction,
       accessibilityNextLabel,
       accessibilityPrevLabel,
       classNames,
-      children
+      children,
+      maskSize,
     } = this.props;
 
     return (
       <div className={cx(css.root, classNames.root)}>
-        <div className={cx(css.header, classNames.header)}>
-          <div className={cx(css.control, css.prevControl)}>
-            <BtnContainer onClick={this.handlePreviousMonth}>
-              <Icon name="chevron" className={css.prevIcon} />
-              <ScreenReadable>{accessibilityPrevLabel}</ScreenReadable>
-            </BtnContainer>
-          </div>
-          <div className={css.month}>{month.format('MMMM YYYY')}</div>
-          <div className={cx(css.control, css.nextControl)}>
-            <BtnContainer onClick={this.handleNextMonth}>
-              <Icon name="chevron" className={css.nextIcon} />
-              <ScreenReadable>{accessibilityNextLabel}</ScreenReadable>
-            </BtnContainer>
-          </div>
-        </div>
-        <CalendarMonth
-          {...this.props}
-          classNames={calendarMonthClassNames}
-          month={month}
-          columnHeadingProps={{
-            ...columnHeadingProps,
-            className: css.columnHeader,
-          }}
-          dayProps={{
-            ...dayProps,
-            onInteraction,
-          }}
-          DayComponent={DayPickerItem}
-        />
-        {children}
+        {[...Array(maskSize)].map((_, i) => {
+          const month = this.props.month.clone().add(i, 'months');
+          return (
+            <div className={css.monthWrapper} key={`month-${month.toISOString()}`}>
+              <div className={cx(css.header, classNames.header)}>
+                <div className={cx(css.control, css.prevControl)}>
+                {i === 0 && (
+                  <BtnContainer onClick={this.handlePreviousMonth}>
+                    <Icon name="chevron" className={css.prevIcon} />
+                    <ScreenReadable>{accessibilityPrevLabel}</ScreenReadable>
+                  </BtnContainer>
+                )}
+                </div>
+                <div className={css.month}>{month.format('MMMM YYYY')}</div>
+                <div className={cx(css.control, css.nextControl)}>
+                {i === maskSize - 1 && (
+                  <BtnContainer onClick={this.handleNextMonth}>
+                    <Icon name="chevron" className={css.nextIcon} />
+                    <ScreenReadable>{accessibilityNextLabel}</ScreenReadable>
+                  </BtnContainer>
+                )}
+                </div>
+              </div>
+              <CalendarMonth
+                {...this.props}
+                classNames={calendarMonthClassNames}
+                month={month}
+                columnHeadingProps={{
+                  ...columnHeadingProps,
+                  className: css.columnHeader,
+                }}
+                dayProps={{
+                  ...dayProps,
+                  onInteraction,
+                }}
+                DayComponent={DayPickerItem}
+              />
+              {children}
+            </div>
+          );
+        })}
       </div>
     );
   }

--- a/packages/playground/stories/DayPicker.story.js
+++ b/packages/playground/stories/DayPicker.story.js
@@ -23,6 +23,7 @@ class StateManagedDayPicker extends Component {
   getDayState = day => {
     const { date } = this.state;
     return Object.assign({}, defaultDayState, {
+      isDisabled: day && day.isBefore(moment(), 'day'),
       isSelected: day && date && day.isSame(date, 'day'),
       isFirstSelected: day && date && day.isSame(date, 'day'),
       isLastSelected: day && date && day.isSame(date, 'day'),
@@ -41,17 +42,15 @@ class StateManagedDayPicker extends Component {
     const { month } = this.state;
 
     return (
-      <div>
-        <DayPicker
-          {...this.props}
-          month={month}
-          onInteraction={this.handleInteraction}
-          onMonthChange={this.handleMonthChange}
-          dayProps={{
-            getDayState: this.getDayState,
-          }}
-        />
-      </div>
+      <DayPicker
+        {...this.props}
+        month={month}
+        onInteraction={this.handleInteraction}
+        onMonthChange={this.handleMonthChange}
+        dayProps={{
+          getDayState: this.getDayState,
+        }}
+      />
     );
   }
 }
@@ -92,4 +91,5 @@ stories
       month={moment({ month: number('month', today.month()) })}
     />
   ))
-  .add('Interactive', () => <StateManagedDayPicker />);
+  .add('Interactive', () => <StateManagedDayPicker />)
+  .add('Interactive with multiple months', () => <StateManagedDayPicker maskSize={3} />);


### PR DESCRIPTION
Passing a `maskSize` to a daypicker will now show a number of
months equal to the `maskSize`.