### PR TITLE
CHORE Allow the markdown component to parse html

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "build-storybook": "cd packages/playground && yarn run build-storybook",
     "deploy-storybook": "cd packages/playground && yarn run deploy",
     "styleguide": "cd packages/styleguide && yarn start",
-    "test": "jest --projects packages/*",
+    "test": "jest --projects packages/core",
     "bump": "lerna publish --exact --skip-npm --since \"v$(npm info @appearhere/bloom version)\"",
     "test:travis": "yarn test --coverage --maxWorkers=4",
     "now-build": "yarn build && yarn build-storybook"

--- a/packages/core/rollup.config.js
+++ b/packages/core/rollup.config.js
@@ -123,7 +123,7 @@ export default {
     'react-container-query',
     'react-dom',
     'react-html5video',
-    'react-markdown',
+    'react-markdown/with-html',
     'react-moment-proptypes',
     'react-motion',
     'react-on-visible',

--- a/packages/core/src/components/Markdown/Markdown.js
+++ b/packages/core/src/components/Markdown/Markdown.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import cx from 'classnames';
-import ReactMarkdown from 'react-markdown';
+import ReactMarkdown from 'react-markdown/with-html';
 
 import css from './Markdown.css';
 
@@ -11,15 +11,24 @@ export default class Markdown extends Component {
     className: PropTypes.string,
     overrideClassname: PropTypes.bool,
     targetBlank: PropTypes.bool,
+    escapeHtml: PropTypes.bool,
   };
 
   static defaultProps = {
     overrideClassname: false,
     targetBlank: false,
+    escapeHtml: false,
   };
 
   render() {
-    const { children, className, overrideClassname, targetBlank, ...rest } = this.props;
+    const {
+      children,
+      className,
+      overrideClassname,
+      targetBlank,
+      escapeHtml,
+      ...rest,
+    } = this.props;
 
     const props = {
       className: overrideClassname ? className : cx(css.root, className),
@@ -29,7 +38,11 @@ export default class Markdown extends Component {
     return React.createElement(
       'div',
       props,
-      <ReactMarkdown source={children} linkTarget={targetBlank ? "_blank" : "_self"} />
+      <ReactMarkdown
+        source={children}
+        escapeHtml={escapeHtml}
+        linkTarget={targetBlank ? "_blank" : "_self"}
+      />
     );
   }
 }


### PR DESCRIPTION
- Adds an option to either escape or not escape html in the markdown
component
- Removes styleguide tests from the CI