### PR TITLE
[PG-2654] 🚀 Run `onCarouselChange` callback `beforeSlide` not after

### DIFF
--- a/packages/core/src/components/Cards/DestinationListingCard/DestinationListingCard.js
+++ b/packages/core/src/components/Cards/DestinationListingCard/DestinationListingCard.js
@@ -136,7 +136,7 @@ class DestinationListingCard extends React.Component<Props, State> {
               wrapAround
               swiping={false}
               dragging={false}
-              afterSlide={onCarouselChange}
+              beforeSlide={onCarouselChange}
               withoutControls
             >
               {images.map(({ src, ...imageProps }) => (


### PR DESCRIPTION
### Description
We've faced issues with Carousel when users would click on the Carousel to get the next image the callback would be called after the Carousel has finished the transition from one image to another rather than before the transition finishes.
This is a problem because we're lazy-loading the images `onCarouselChange` and there's ~0.5 second delay in between when the user clicks to see the next image in the carousel and when we actually load it.

This solves the problem by calling the `onCarouselChange` before the slide transition completes and giving us more time to load the image and make the lazy-load smoother.

Note: this is a breaking change as the `beforeSlide` calls the callback with different parameters than `afterSlide`.

The current behaviour passes an index of the nextImage (the one we're transitioning into) whereas `beforeSlide` passes this as a second parameter, the first parameter being the `currentSlide` the Carousel is on.