### PR TITLE
Optionally truncate text for district card

### DIFF
--- a/packages/core/src/components/Cards/DistrictCard/DistrictCard.css
+++ b/packages/core/src/components/Cards/DistrictCard/DistrictCard.css
@@ -34,33 +34,42 @@
 }
 
 .title {
-  font-family: var(--font-avenir);
-  font-size: var(--fontsize-regular);
+  font: var(--font-regular);
   font-weight: var(--fontweight-demi);
+  letter-spacing: var(--letter-spacing-large-i);
   line-height: 1.74583125rem;
   color: var(--color-black);
   margin: 0 0 0.25rem 0;
   padding: 0;
   text-decoration: none;
-  white-space: nowrap;
   overflow: hidden;
+}
+
+.truncated {
   text-overflow: ellipsis;
 }
 
+.title.truncated {
+  white-space: nowrap;
+}
+
+.subtitle.truncated {
+  word-break: break-word;
+  white-space: unset;
+  -webkit-line-clamp: 2;
+}
+
 .subtitle {
-  font-family: var(--font-avenir);
-  font-size: var(--fontsize-small-i);
+  font: var(--font-small-i);
+  letter-spacing: var(--letter-spacing-large-i);
   line-height: 1.43020625rem;
   color: var(--color-grey);
   margin: 0 auto;
   padding: 0;
   display: -webkit-box;
-  -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
   overflow: hidden;
-  text-overflow: ellipsis;
   height: auto;/* Fallback for non-webkit */
-  word-break: break-word;
 }
 
 @media(min-width: 48rem) {

--- a/packages/core/src/components/Cards/DistrictCard/DistrictCard.js
+++ b/packages/core/src/components/Cards/DistrictCard/DistrictCard.js
@@ -3,6 +3,7 @@ import React from 'react';
 import css from './DistrictCard.css';
 import FittedImage from "../../FittedImage/FittedImage";
 import Card from "../Card/Card";
+import cx from 'classnames';
 
 type Props = {
   title: string,
@@ -10,11 +11,12 @@ type Props = {
   src: string,
   alt: string,
   href: string,
+  truncateText: boolean,
 }
 
 
 const DistrictCard = (props: Props) => {
-  const {title, subtitle, src, alt, href, ...rest} = props;
+  const {title, subtitle, src, alt, href, truncateText = true, ...rest} = props;
 
   return (
     <Card href={href} className={css.district} {...(rest: any)}>
@@ -23,11 +25,17 @@ const DistrictCard = (props: Props) => {
       </div>
 
       <div className={css.content}>
-        <h3 className={css.title}>{title}</h3>
-        { subtitle && <p className={css.subtitle}>{subtitle}</p> }
+        <h3 className={cx(css.title, { [css.truncated]: truncateText })}>{title}</h3>
+        { subtitle &&
+          <p className={cx(css.subtitle, { [css.truncated]: truncateText })}>{subtitle}</p>
+        }
       </div>
     </Card>
   );
+};
+
+DistrictCard.defaultProps = {
+  truncateText: true,
 };
 
 

--- a/packages/playground/stories/Cards.story.js
+++ b/packages/playground/stories/Cards.story.js
@@ -31,6 +31,16 @@ storiesOf('Cards', module)
       href="#"
     />
   ))
+  .add('District Card without text truncation', () => (
+    <DistrictCard
+      title="Covent Garden"
+      subtitle="A haven for pleasure and procrastination"
+      src="https://picsum.photos/500"
+      alt="hello"
+      href="#"
+      truncateText={false}
+    />
+  ))
   .add('District Card without subtitle', () => (
     <DistrictCard
       title="Covent Garden"


### PR DESCRIPTION
By default we truncate the text on the title and subtitle, we want to be able to turn off this default behaviour via a prop.