### PR TITLE
PG-2749 Fix the dismissable panel style

### DIFF
--- a/packages/core/src/components/DismissablePanel/DismissablePanel.css
+++ b/packages/core/src/components/DismissablePanel/DismissablePanel.css
@@ -1,26 +1,11 @@
 .root {
-  display: table;
+  display: flex;
   padding-top: var(--size-lg-i);
   padding-bottom: var(--size-lg-i);
+  justify-content: space-between;
+  align-items: center;
 }
 
 .inner {
-  display: table-cell;
-  width: 100%;
-  vertical-align: middle;
-}
-
-.dismissable .inner {
-  width: 99%;
-}
-
-.dismissContainer {
-  display: table-cell;
-  min-width: 1%;
-  vertical-align: top;
-}
-
-.icon {
-  display: block;
-  margin-left: var(--size-medium);
+  width: 90%;
 }


### PR DESCRIPTION
- The cross icon was appearing below the content, it should be pulled to
the right

![image](https://user-images.githubusercontent.com/17271241/75035912-8886dc80-54a8-11ea-961e-ddfcbe81ccdf.png)
