### PR TITLE
PG-2749 Ensure parent styles are used for Panel.js

### DIFF
--- a/packages/core/src/components/Panel/Panel.js
+++ b/packages/core/src/components/Panel/Panel.js
@@ -26,7 +26,7 @@ const Panel = (props: Props) => {
   const { children, className, context, ...rest } = props;
 
   return (
-    <div {...rest} className={cx(css.root, css[context], className)}>
+    <div {...rest} className={cx(className, css.root, css[context])}>
       {children}
     </div>
   );


### PR DESCRIPTION
- Some styles passed into the child `Panel` component via the
`className` prop from the parent `DismissablePanel` were getting
overwritten by the root styles for the `Panel`.
- This meant that `DismissablePanel` was not displaying the correct way
due to `display` style getting overwritten.
- This commit ensures that styles passed in via `className` take precedence