### PR TITLE
PG-2749 Increase specificty of DismissablePanel styles

### DIFF
--- a/packages/core/src/components/DismissablePanel/DismissablePanel.css
+++ b/packages/core/src/components/DismissablePanel/DismissablePanel.css
@@ -1,4 +1,4 @@
-.root {
+div.root {
   display: flex;
   padding-top: var(--size-lg-i);
   padding-bottom: var(--size-lg-i);

--- a/packages/core/src/components/Panel/Panel.js
+++ b/packages/core/src/components/Panel/Panel.js
@@ -26,7 +26,7 @@ const Panel = (props: Props) => {
   const { children, className, context, ...rest } = props;
 
   return (
-    <div {...rest} className={cx(className, css.root, css[context])}>
+    <div {...rest} className={cx(css.root, css[context], className)}>
       {children}
     </div>
   );


### PR DESCRIPTION
- `DismissablePanel` styles were getting overwritten by the `Panel`
child component's styles. This commit increases the specificity of
the `DismissablePanel` root css to make sure it takes precedence.