### PR TITLE
Add focus to IconInput

### DIFF
--- a/packages/core/src/components/Form/IconInput/IconInput.js
+++ b/packages/core/src/components/Form/IconInput/IconInput.js
@@ -17,7 +17,6 @@ type Props = {
   iconName: string,
   iconSide: 'left' | 'right',
   iconDimensions: IconDimensions,
-  onIconClick: () => void,
 }
 
 export default class IconInput extends Component<Props> {
@@ -29,8 +28,8 @@ export default class IconInput extends Component<Props> {
     iconDimensions: { height: '1em', width: '1em' },
   };
 
-  iconClick = (): void => {
-    this.props.onIconClick ? this.props.onIconClick() : this.input.focus();
+  focus = (): void => {
+    this.input.focus();
   };
 
   blur = (): void => {
@@ -38,13 +37,13 @@ export default class IconInput extends Component<Props> {
   };
 
   render() {
-    const { classNames, iconName, iconSide, iconDimensions, onIconClick, ...rest } = this.props;
+    const { classNames, iconName, iconSide, iconDimensions, ...rest } = this.props;
 
     return (
       <div className={cx(css.root, css[iconSide], classNames.root)}>
         <Icon
           className={cx(css.icon, classNames.icon)}
-          onClick={this.iconClick}
+          onClick={this.focus}
           name={iconName}
           dimensions={iconDimensions}
         />

--- a/packages/core/src/components/Icon/iconHelper.js
+++ b/packages/core/src/components/Icon/iconHelper.js
@@ -12,7 +12,6 @@ type Props = {
   name: string,
   className?: string,
   dimensions: Dimensions,
-  onClick?: () => void,
 }
 
 export default (iconSet: Object, theme: any) =>
@@ -23,7 +22,7 @@ export default (iconSet: Object, theme: any) =>
     };
 
     render() {
-      const { className, name, dimensions, onClick } = this.props;
+      const { className, name, dimensions } = this.props;
       const IconComponent = iconSet[name];
 
       const classes = classnames(
@@ -35,7 +34,7 @@ export default (iconSet: Object, theme: any) =>
 
       /* eslint-disable react/no-danger */
       return (
-        <span className={classes} onClick={onClick}>
+        <span className={classes}>
           <IconComponent height={dimensions.height} width={dimensions.width} />
         </span>
       );

--- a/packages/playground/stories/IconInput.story.js
+++ b/packages/playground/stories/IconInput.story.js
@@ -60,17 +60,4 @@ stories
       onChange={action('Change')}
       error={boolean('Errored', false) ? 'Something went wrong' : ''}
     />
-  ))
-  .add('IconInput w/ custom onIconClick', () => (
-    <IconInput
-      iconName="search"
-      id="1"
-      type={select('Type', inputTypes, inputTypes[0])}
-      value="London"
-      onFocus={action('Focus')}
-      onBlur={action('Blur')}
-      onChange={action('Change')}
-      onIconClick={action('Icon Clicked')}
-      error={boolean('Errored', false) ? 'Something went wrong' : ''}
-    />
   ));


### PR DESCRIPTION
This reverts commit ef7a42c, reversing changes made to 590d898.

We shouldn't add a click event to an icon within an input as it causes accessibility issues, if we want to be able to click the icon, we should render a button next to the input which ican be focused, tabbed etc.