### PR TITLE
PG-2971 add coloured days on daypicker

### DIFF
--- a/packages/core/src/components/Calendar/DayPicker/DayPickerItem.css
+++ b/packages/core/src/components/Calendar/DayPicker/DayPickerItem.css
@@ -17,7 +17,6 @@
 }
 
 .closed {
-  color: var(--color-greyLight);
   text-decoration: line-through;
 }
 
@@ -50,4 +49,34 @@
 .lastSelected.highlighted:not(.firstHighlighted) {
   border-top-left-radius: 0;
   border-bottom-left-radius: 0;
+}
+
+.green {
+  background-color: #D3E7D5;
+  color: #395d3b;
+}
+
+.green.selected {
+  background-color: #7bb080;
+  color: #395d3b;
+}
+
+.orange {
+  background-color: #fff2e4;
+  color: #9f5d10;
+}
+
+.orange.selected {
+  background-color: #F5CA99;
+  color: #9f5d10;
+}
+
+.red {
+  background-color: #f0bfbf;
+  color: #770606;
+}
+
+.red.selected {
+  background-color: #DD7C7C;
+  color: #770606;
 }

--- a/packages/core/src/components/Calendar/DayPicker/DayPickerItem.js
+++ b/packages/core/src/components/Calendar/DayPicker/DayPickerItem.js
@@ -18,6 +18,9 @@ export const defaultDayState = {
   isFirstHighlighted: false,
   isLastHighlighted: false,
   subtext: undefined,
+  isGreen: false,
+  isOrange: false,
+  isRed: false,
 };
 
 const defaultGetDateState = () => defaultDayState;
@@ -78,7 +81,6 @@ export default class DayPickerItem extends Component<Props> {
       getDayState,
       ...rest
     } = this.props;
-
     const state = getDayState(day);
 
     const className = cx(
@@ -91,6 +93,9 @@ export default class DayPickerItem extends Component<Props> {
       state.isFirstHighlighted ? css.firstHighlighted : null,
       state.isLastHighlighted ? css.lastHighlighted : null,
       state.isClosed ? css.closed : null,
+      state.isGreen ? css.green : null,
+      state.isOrange ? css.orange : null,
+      state.isRed ? css.red : null,
     );
 
     return (


### PR DESCRIPTION
In order for us to differentiate between 100% available, 100% unavailabe, underoffer and unknown availability, we have added three further colours for the daypicker.