### PR TITLE
PG-3060 Fix minimist security vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,10 @@
     "macaddress": "^0.2.9",
     "webpack-dev-server": "^2.11.4",
     "serialize-javascript": "^2.1.1",
-    "mem": "^4.0.0"
+    "mem": "^4.0.0",
+    "**/optimist/**/minimist": "^0.2.1",
+    "**/mkdirp/**/minimist": "^0.2.1",
+    "**/strong-log-transformer/**/minimist": "^0.2.1"
+
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11594,25 +11594,15 @@ minimist-options@^3.0.1:
     arrify "^1.0.1"
     is-plain-obj "^1.1.0"
 
-minimist@0.0.8:
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
-  integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
-
-minimist@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.1.0.tgz#99df657a52574c21c9057497df742790b2b4c0de"
-  integrity sha1-md9lelJXTCHJBXSX33QnkLK0wN4=
+minimist@0.0.8, minimist@^0.1.0, minimist@^0.2.1, minimist@~0.0.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.2.1.tgz#827ba4e7593464e7c221e8c5bed930904ee2c455"
+  integrity sha512-GY8fANSrTMfBVfInqJAY41QkOM+upUTytK1jZ0c8+3HdHrJxBJ3rF5i9moClXTE8uUSnUo8cAsCoxDXvSY4DHg==
 
 minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, "minimist@~ 1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
   integrity sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=
-
-minimist@~0.0.1:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
-  integrity sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=
 
 mississippi@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
- Versions below 0.2.1 have a security vulnerability
https://snyk.io/vuln/SNYK-JS-MINIMIST-559764
- Resolve minimist to 0.2.1 to fix the vulnerability