### PR TITLE
[CHORE] Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,32 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+* @appearhere/developers
+
+# Order is important; the last matching pattern takes the most
+# precedence. When someone opens a pull request that only
+# modifies JS files, only @js-owner and not the global
+# owner(s) will be requested for a review.
+# *.js    @js-owner
+
+# You can also use email addresses if you prefer. They'll be
+# used to look up users just like we do for commit author
+# emails.
+# *.go docs@example.com
+
+# In this example, @doctocat owns any files in the build/logs
+# directory at the root of the repository and any of its
+# subdirectories.
+# /build/logs/ @doctocat
+
+# The `docs/*` pattern will match files like
+# `docs/getting-started.md` but not further nested files like
+# `docs/build-app/troubleshooting.md`.
+# docs/*  docs@example.com
+
+# In this example, @octocat owns any file in an apps directory
+# anywhere in your repository.
+# apps/ @octocat
+
+# In this example, @doctocat owns any file in the `/docs`
+# directory in the root of your repository.
+# /docs/ @doctocat


### PR DESCRIPTION
This will help notify us on automated PRs created by `dependabot`.

Most of the file is commented for now, except https://github.com/appearhere/bloom/compare/chore/add-code-owners?expand=1#diff-5cfb934ca0ec4c1743905a51dc428b84R3 which sets a rule to notify the entire `@developers` group

Read more about code owners here:
https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners