### PR TITLE
CHORE: Add cname file during deployment

### DIFF
--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -26,6 +26,6 @@
   "scripts": {
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",
-    "deploy": "storybook-to-ghpages --out=../../docs --ci"
+    "deploy": "yarn run build-storybook && echo 'bloom.appearhere.co.uk' > './storybook-static/CNAME' && storybook-to-ghpages --existing-output-dir=./storybook-static --ci"
   }
 }


### PR DESCRIPTION
Since using a custom domain for gihub pages, we need to have a cname file as part of the deployment.