### PR TITLE
LFR-2598 add classnames to withCross modal component

### DIFF
--- a/packages/core/src/components/Modal/WithCross.js
+++ b/packages/core/src/components/Modal/WithCross.js
@@ -14,24 +14,32 @@ import BtnContainer from '../BtnContainer/BtnContainer';
  * TODO: Figure out react-motion compatible focus trap
  */
 
+type ClassNames = {
+  dismissContainer: string,
+ }
+
 type Props = {
   children: React.Node,
   onClose: Function,
   variant: 'light' | 'dark',
+  classNames: ClassNames,
 }
 
 class WindowWithCross extends React.Component<Props> {
   static defaultProps = {
     onClose: noop,
     variant: 'light',
+    classNames: {
+      dismissContainer: '',
+    }
   };
 
   render() {
-    const { children, onClose, variant, ...rest } = this.props;
+    const { children, onClose, variant, classNames, ...rest } = this.props;
 
     return (
       <Window {...rest} variant={variant}>
-        <BtnContainer className={css.dismissContainer} onClick={onClose}>
+        <BtnContainer className={cx(css.dismissContainer, classNames.dismissContainer)} onClick={onClose}>
           <Icon className={css.icon} name="cross" />
         </BtnContainer>
         <div className={cx(css.inner, m.cf)}>{children}</div>


### PR DESCRIPTION
In order to add some customisation of the placement of the cross of the WithCross modal, the classNames property was added

![image](https://user-images.githubusercontent.com/1364253/87087245-afad3300-c22a-11ea-8a32-2d14bd6d5677.png)
