### PR TITLE
Add icon to badge component

### DIFF
--- a/packages/core/src/components/Badge/Badge.css
+++ b/packages/core/src/components/Badge/Badge.css
@@ -39,3 +39,7 @@
   color: var(--color-black);
   border-color: currentColor;
 }
+
+.icon {
+  padding-right: var(--size-micro);
+}

--- a/packages/core/src/components/Badge/Badge.js
+++ b/packages/core/src/components/Badge/Badge.js
@@ -1,6 +1,7 @@
 // @flow
 import React from 'react';
 import classNames from 'classnames/bind';
+import Icon from '../Icon/Icon';
 
 import css from './Badge.css';
 
@@ -11,10 +12,12 @@ type Props = {
   children: any,
   context: 'primary' | 'special',
   hollow?: boolean,
+  icon?: string,
 }
 
-const Badge = ({ className, children, context, hollow, ...rest }: Props) => (
+const Badge = ({ className, children, context, hollow, icon, ...rest }: Props) => (
   <span {...rest} className={cx(css.root, css[context], hollow ? css.hollow : null, className)}>
+    {icon && <Icon className={css.icon} name={icon}/>}
     {children}
   </span>
 );

--- a/packages/playground/stories/Badge.story.js
+++ b/packages/playground/stories/Badge.story.js
@@ -16,4 +16,9 @@ storiesOf('Badge', module)
     <Badge context="special" hollow>
       Collection
     </Badge>
+  ))
+  .add('With icon', () => (
+    <Badge icon="price-tag">
+      50% Discount
+    </Badge>
   ));


### PR DESCRIPTION
<img width="123" alt="Screenshot 2020-07-29 at 16 06 33" src="https://user-images.githubusercontent.com/43782388/88909219-c0adfa80-d252-11ea-84fa-07055f928885.png">

Adds the icon prop to the badge component so you can pass down an icon name.