### PR TITLE
Fix the icon cross colour

### DIFF
--- a/packages/core/src/components/Icon/icons/icon-cross.svg
+++ b/packages/core/src/components/Icon/icons/icon-cross.svg
@@ -5,7 +5,7 @@
     <desc>Created with Sketch.</desc>
     <defs></defs>
     <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="icon-x" fill="#191919">
+        <g id="icon-x" fill="currentColor">
             <path d="M9,7 L9,1 L7,1 L7,7 L1,7 L1,9 L7,9 L7,15 L9,15 L9,9 L15,9 L15,7 L9,7 Z" id="Combined-Shape" transform="translate(8.000000, 8.000000) rotate(45.000000) translate(-8.000000, -8.000000) "></path>
         </g>
     </g>


### PR DESCRIPTION
When displaying the dismissable panel with a cross, update the
icon colour to match the font colour