### PR TITLE
Improve tabs

### DIFF
--- a/packages/core/src/components/Tabs/Tabs.js
+++ b/packages/core/src/components/Tabs/Tabs.js
@@ -86,7 +86,7 @@ export default class Tabs extends React.Component<Props, State> {
           <span id={`${this.id}-description`}>{accessibilityDescription}</span>
         </ScreenReadable>
         <div className={css.tabsContainer}>
-          {React.Children.map(children, (child, i) => {
+          {React.Children.toArray(children).filter(Boolean).map((child, i) => {
             const id = `${this.id}-${i}-tab`;
 
             return React.cloneElement(
@@ -112,7 +112,7 @@ export default class Tabs extends React.Component<Props, State> {
           })}
         </div>
         <div className={css.tabsContent}>
-          {React.Children.map(children, (child, i) => {
+          {React.Children.toArray(children).filter(Boolean).map((child, i) => {
             const id = `${this.id}-${i}-panel`;
             const classes = cx(css.tabContent, activeTabIndex === i ? css.tabContentActive : null);
 

--- a/packages/core/src/components/Tabs/Tabs.js
+++ b/packages/core/src/components/Tabs/Tabs.js
@@ -15,6 +15,7 @@ import css from './Tabs.css';
 type Props = {
   accessibilityDescription: string,
   children: React.Node,
+  initialActiveTabIndex: number,
 }
 
 type State = {
@@ -36,7 +37,7 @@ export default class Tabs extends React.Component<Props, State> {
   }
 
   state = {
-    activeTabIndex: 0,
+    activeTabIndex: this.props.initialActiveTabIndex || 0,
     focusedTabIndex: null,
   };
 

--- a/packages/core/src/components/Tabs/Tabs.js
+++ b/packages/core/src/components/Tabs/Tabs.js
@@ -23,6 +23,8 @@ type State = {
   focusedTabIndex: ?number,
 }
 
+type Callback<T> = (e?: T) => void;
+
 export default class Tabs extends React.Component<Props, State> {
   id: string;
 
@@ -52,19 +54,28 @@ export default class Tabs extends React.Component<Props, State> {
     this.tabs[i].focus();
   };
 
-  handleClick = (e: SyntheticEvent<>, i: number) => {
+  handleClick = (onClick: Callback<SyntheticEvent<>>) => (e: SyntheticEvent<>, i: number) => {
     this.updateTabIndexes(i);
+    if (onClick) {
+      onClick(e)
+    }
   };
 
-  handleFocus = (e: SyntheticEvent<>, i: number) => {
+  handleFocus = (onFocus: Callback<SyntheticEvent<>>) => (e: SyntheticEvent<>, i: number) => {
     this.setState({ focusedTabIndex: i });
+    if(onFocus) {
+      onFocus(e);
+    }
   };
 
-  handleBlur = () => {
+  handleBlur = (onBlur: Callback<SyntheticEvent<>>) => () => {
     this.setState({ focusedTabIndex: null });
+    if (onBlur) {
+      onBlur();
+    }
   };
 
-  handleKeyDown = (e: KeyboardEvent) => {
+  handleKeyDown = (onKeyDown: Callback<KeyboardEvent>) => (e: KeyboardEvent) => {
     const { activeTabIndex } = this.state;
     const { children } = this.props;
     const i = keyboardHandler(e.which, activeTabIndex, React.Children.count(children));
@@ -74,6 +85,10 @@ export default class Tabs extends React.Component<Props, State> {
       e.stopPropagation();
 
       this.updateTabIndexes(i);
+    }
+
+    if (onKeyDown) {
+      onKeyDown(e);
     }
   };
 
@@ -100,10 +115,10 @@ export default class Tabs extends React.Component<Props, State> {
                 id,
                 value: i,
                 selected: activeTabIndex === i,
-                onClick: this.handleClick,
-                onFocus: this.handleFocus,
-                onBlur: this.handleBlur,
-                onKeyDown: this.handleKeyDown,
+                onClick: this.handleClick(child.props.onClick),
+                onFocus: this.handleFocus(child.props.onFocus),
+                onBlur: this.handleBlur(child.props.onBlur),
+                onKeyDown: this.handleKeyDown(child.props.onKeyDown),
                 'aria-controls': `${this.id}-${i}-panel`,
                 'aria-describedby': `${this.id}-description`,
                 role: 'tab',

--- a/packages/playground/stories/Tabs.story.js
+++ b/packages/playground/stories/Tabs.story.js
@@ -42,4 +42,38 @@ storiesOf('Tabs', module).add('Default', () => (
       </Tab>
     </Tabs>
   </div>
+)).add('With Initially selected tab', () => (
+  <div>
+    <Tabs onChange={action('Changed tab')} initialActiveTabIndex={1}>
+      <Tab label="Sail - AWOLNATION">
+        <iframe
+          width="560"
+          height="315"
+          src="https://www.youtube.com/embed/Awf45u6zrP0"
+          frameBorder="0"
+          allowFullScreen
+        />
+      </Tab>
+      {!boolean('Remove Tab', false) && (
+        <Tab label="Will Sasso">
+          <iframe
+            width="560"
+            height="315"
+            src="https://www.youtube.com/embed/T6i5qHHXjz0"
+            frameBorder="0"
+            allowFullScreen
+          />
+        </Tab>
+      )}
+      <Tab label="Go go Power Rangers!">
+        <iframe
+          width="560"
+          height="315"
+          src="https://www.youtube.com/embed/7Wt6XlVob_E"
+          frameBorder="0"
+          allowFullScreen
+        />
+      </Tab>
+    </Tabs>
+  </div>
 )).addDecorator(withKnobs);

--- a/packages/playground/stories/Tabs.story.js
+++ b/packages/playground/stories/Tabs.story.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
+import { withKnobs, boolean } from '@storybook/addon-knobs';
 
 import {
   Tabs,
@@ -19,15 +20,17 @@ storiesOf('Tabs', module).add('Default', () => (
           allowFullScreen
         />
       </Tab>
-      <Tab label="Will Sasso">
-        <iframe
-          width="560"
-          height="315"
-          src="https://www.youtube.com/embed/T6i5qHHXjz0"
-          frameBorder="0"
-          allowFullScreen
-        />
-      </Tab>
+      {!boolean('Remove Tab', false) && (
+        <Tab label="Will Sasso">
+          <iframe
+            width="560"
+            height="315"
+            src="https://www.youtube.com/embed/T6i5qHHXjz0"
+            frameBorder="0"
+            allowFullScreen
+          />
+        </Tab>
+      )}
       <Tab label="Go go Power Rangers!">
         <iframe
           width="560"
@@ -39,4 +42,4 @@ storiesOf('Tabs', module).add('Default', () => (
       </Tab>
     </Tabs>
   </div>
-));
+)).addDecorator(withKnobs);


### PR DESCRIPTION
* When rendering tabs, we loop through the children, we should ignore null children.
* Preserve the child callback props for the tabs
* Allow defining an initially selected tab other than the first