### PR TITLE
AHP-359 Set label to only render if present to prevent empty top padding

### DIFF
--- a/packages/core/src/components/Form/InputField/InputField.js
+++ b/packages/core/src/components/Form/InputField/InputField.js
@@ -71,14 +71,16 @@ export default class InputField extends React.Component<Props> {
             {meta}
           </Meta>
         )}
-        <Label
-          {...sharedProps}
-          htmlFor={id}
-          className={classNames.label}
-          optionalLabel={!required ? optionalLabel : undefined}
-        >
-          {label}
-        </Label>
+        {label && (
+          <Label
+              {...sharedProps}
+              htmlFor={id}
+              className={classNames.label}
+              optionalLabel={!required ? optionalLabel : undefined}
+          >
+            {label}
+          </Label>
+        )}
         {!valueReplay && placeholderValue && (
           <Placeholder {...sharedProps} className={classNames.valueReplay}>
             {placeholderValue}

--- a/packages/core/src/components/Form/InputField/InputField.test.js
+++ b/packages/core/src/components/Form/InputField/InputField.test.js
@@ -12,3 +12,25 @@ it('renders without crashing', () => {
     div,
   );
 });
+
+it('renders label if passed a label prop', () => {
+  const {container} = render(
+    <InputField label="Test Label">
+      <input />
+    </InputField>,
+  )
+
+  const labelField = container.querySelector('Label');
+  expect(labelField).toBeVisible();
+})
+
+it('does not render label if not passed a label prop', () => {
+  const {container} = render(
+    <InputField>
+      <input />
+    </InputField>,
+  )
+
+  const labelField = container.querySelector('Label');
+  expect(labelField).toBeFalsy();
+})


### PR DESCRIPTION
We currently render an empty container for a label even when a label isn't needed on the Input Field. This commit sets the label to render only if a label field is passed to ensure styling consistency.